### PR TITLE
Add Phase 1 query set creation tools

### DIFF
--- a/influence-workbench/backend/app.py
+++ b/influence-workbench/backend/app.py
@@ -6,15 +6,18 @@ import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import httpx
 from fastapi import FastAPI
 
+from backend.clients.claude import ClaudeClient
+from backend.clients.infinigram import InfinigramClient
 from backend.config import WorkbenchConfig, load_config
 from backend.db import get_connection, init_db
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Startup: load config, init DB, create semaphore."""
+    """Startup: load config, init DB, create semaphore, init API clients."""
     config = load_config(app.state.config_path)
     data_dir = Path(config.data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -23,14 +26,24 @@ async def lifespan(app: FastAPI):
     await init_db(db_path)
     conn = await get_connection(db_path)
 
+    http_client = httpx.AsyncClient()
+
     app.state.config = config
     app.state.db = conn
     app.state.db_path = str(db_path)
     app.state.run_semaphore = asyncio.Semaphore(config.max_concurrent_runs)
     app.state.log_subscribers = {}  # run_id -> set of asyncio.Queue
+    app.state.http_client = http_client
+    app.state.infinigram_client = InfinigramClient(
+        http_client=http_client,
+        api_url=config.infinigram_api_url,
+        index=config.infinigram_index,
+    )
+    app.state.claude_client = ClaudeClient(model=config.claude_model)
 
     yield
 
+    await http_client.aclose()
     await conn.close()
 
 
@@ -41,9 +54,11 @@ def create_app(config_path: str = "config.yaml") -> FastAPI:
 
     from backend.routes.probe_sets import router as probe_sets_router
     from backend.routes.runs import router as runs_router
+    from backend.routes.tools import router as tools_router
 
     app.include_router(probe_sets_router)
     app.include_router(runs_router)
+    app.include_router(tools_router)
 
     return app
 

--- a/influence-workbench/backend/clients/claude.py
+++ b/influence-workbench/backend/clients/claude.py
@@ -1,0 +1,37 @@
+"""Claude API client wrapping anthropic.AsyncAnthropic."""
+
+from __future__ import annotations
+
+import anthropic
+
+
+class ClaudeClient:
+    def __init__(self, api_key: str | None = None, model: str = "claude-haiku-4-5-20251001"):
+        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        self._model = model
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def generate_context(self, completion: str, instruction: str | None = None) -> str:
+        """Generate a plausible prompt that naturally precedes *completion*."""
+        system = (
+            "You are a helpful assistant. Your task is to generate a plausible "
+            "context or prompt that would naturally precede the given completion text. "
+            "The context should read as if it came from a real document, article, or "
+            "conversation. Output ONLY the context text, nothing else."
+        )
+
+        user_parts = []
+        if instruction:
+            user_parts.append(f"Instruction: {instruction}\n\n")
+        user_parts.append(f"Completion text:\n{completion}")
+
+        response = await self._client.messages.create(
+            model=self._model,
+            max_tokens=1024,
+            system=system,
+            messages=[{"role": "user", "content": "".join(user_parts)}],
+        )
+        return response.content[0].text

--- a/influence-workbench/backend/clients/infinigram.py
+++ b/influence-workbench/backend/clients/infinigram.py
@@ -1,0 +1,66 @@
+"""Infini-gram API client using the search_docs endpoint."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class InfinigramClient:
+    def __init__(self, http_client: httpx.AsyncClient, api_url: str, index: str):
+        self._http = http_client
+        self._api_url = api_url.rstrip("/")
+        self._index = index
+
+    async def _post(self, payload: dict) -> dict:
+        resp = await self._http.post(self._api_url, json=payload, timeout=30.0)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def search(self, query: str, max_docs: int = 10) -> dict:
+        """Search for *query* and return matching documents.
+
+        Uses the ``search_docs`` query type which returns documents with
+        properly highlighted match spans.
+
+        Returns a dict with keys: documents, query, count.
+        """
+        result = await self._post(
+            {
+                "index": self._index,
+                "query_type": "search_docs",
+                "query": query,
+                "maxnum": max_docs,
+            }
+        )
+
+        count = result.get("cnt", 0)
+        if count == 0:
+            return {"documents": [], "query": query, "count": 0}
+
+        documents = []
+        for doc in result.get("documents", []):
+            # Spans from search_docs are 2-element arrays: [text, highlight]
+            # highlight is None for non-match, an integer (e.g. 0) for match
+            raw_spans = doc.get("spans", [])
+            doc_spans = []
+            for span in raw_spans:
+                if isinstance(span, list) and len(span) >= 2:
+                    doc_spans.append(
+                        {
+                            "text": span[0],
+                            "is_match": span[1] is not None,
+                        }
+                    )
+
+            full_text = "".join(s["text"] for s in doc_spans)
+            documents.append(
+                {
+                    "doc_ix": doc.get("doc_ix", 0),
+                    "doc_len": doc.get("doc_len", 0),
+                    "disp_len": doc.get("disp_len", 0),
+                    "spans": doc_spans,
+                    "full_text": full_text,
+                }
+            )
+
+        return {"documents": documents, "query": query, "count": count}

--- a/influence-workbench/backend/config.py
+++ b/influence-workbench/backend/config.py
@@ -19,6 +19,10 @@ class WorkbenchConfig(BaseModel):
     max_length: int = 512
     if_query_dir: str = "../if-query"
     data_dir: str = "data"
+    infinigram_api_url: str = "https://api.infini-gram.io/"
+    infinigram_index: str = "v4_olmo-mix-1124_llama"
+    infinigram_max_docs: int = 10
+    claude_model: str = "claude-haiku-4-5-20251001"
 
 
 def load_config(path: str | Path = "config.yaml") -> WorkbenchConfig:

--- a/influence-workbench/backend/models.py
+++ b/influence-workbench/backend/models.py
@@ -91,3 +91,74 @@ class RunResults(BaseModel):
     query_results: list[dict]
     train_results: list[dict]
     influences: list[dict]
+
+
+# ---------------------------------------------------------------------------
+# Tool models — Infini-gram search
+# ---------------------------------------------------------------------------
+
+
+class SearchPretrainingRequest(BaseModel):
+    completion: str
+    max_docs: int = 10
+
+
+class InfinigramDocSpan(BaseModel):
+    text: str
+    is_match: bool
+
+
+class InfinigramDocument(BaseModel):
+    doc_ix: int
+    doc_len: int
+    disp_len: int
+    spans: list[InfinigramDocSpan]
+    full_text: str
+
+
+class SearchPretrainingResponse(BaseModel):
+    documents: list[InfinigramDocument]
+    query: str
+    count: int
+
+
+# ---------------------------------------------------------------------------
+# Tool models — Span extraction
+# ---------------------------------------------------------------------------
+
+
+class ExtractSpanRequest(BaseModel):
+    document_text: str
+    match_start: int
+    match_end: int
+    span_length: int = 256
+
+
+class ExtractSpanResponse(BaseModel):
+    prompt: str
+    completion: str
+
+
+# ---------------------------------------------------------------------------
+# Tool models — Claude context generation
+# ---------------------------------------------------------------------------
+
+
+class GenerateContextRequest(BaseModel):
+    completion: str
+    instruction: Optional[str] = None
+
+
+class GenerateContextResponse(BaseModel):
+    generated_prompt: str
+    model: str
+
+
+# ---------------------------------------------------------------------------
+# Tool models — Bulk operations
+# ---------------------------------------------------------------------------
+
+
+class BulkRoleRequest(BaseModel):
+    pair_ids: list[str]
+    role: PairRole

--- a/influence-workbench/backend/routes/probe_sets.py
+++ b/influence-workbench/backend/routes/probe_sets.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile
 
 from backend import db
 from backend.models import (
+    BulkRoleRequest,
     Pair,
+    PairRole,
     ProbeSetCreate,
     ProbeSetDetail,
     ProbeSetUpdate,
@@ -127,3 +131,78 @@ async def delete_probe_set(probe_set_id: str, request: Request) -> Response:
         raise HTTPException(status_code=404, detail="Probe set not found")
     # Note: pairs files left on disk for now; could clean up in production
     return Response(status_code=204)
+
+
+@router.post("/{probe_set_id}/import-pairs")
+async def import_pairs(
+    probe_set_id: str, request: Request, file: UploadFile = File(...)
+) -> ProbeSetDetail:
+    """Import pairs from a CSV or JSON file, appending to existing pairs."""
+    conn = request.app.state.db
+    data_dir = request.app.state.config.data_dir
+    row = await db.get_probe_set(conn, probe_set_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Probe set not found")
+
+    content = await file.read()
+    text = content.decode("utf-8")
+    filename = file.filename or ""
+
+    new_pairs: list[Pair] = []
+    try:
+        if filename.endswith(".json"):
+            raw = json.loads(text)
+            if not isinstance(raw, list):
+                raise ValueError("JSON must be an array of pair objects")
+            for item in raw:
+                new_pairs.append(Pair(**item))
+        else:
+            # Default to CSV
+            reader = csv.DictReader(io.StringIO(text))
+            for row_data in reader:
+                new_pairs.append(
+                    Pair(
+                        pair_id=row_data.get("pair_id", f"p{uuid.uuid4().hex[:8]}"),
+                        prompt=row_data.get("prompt", ""),
+                        completion=row_data.get("completion", ""),
+                        role=PairRole(row_data.get("role", "both")),
+                    )
+                )
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to parse file: {exc}")
+
+    existing_pairs = _read_pairs(data_dir, probe_set_id)
+    all_pairs = existing_pairs + new_pairs
+    _write_pairs(data_dir, probe_set_id, all_pairs)
+
+    now = datetime.now(timezone.utc).isoformat()
+    await db.update_probe_set(conn, probe_set_id, updated_at=now)
+
+    updated_row = await db.get_probe_set(conn, probe_set_id)
+    return _make_detail(updated_row, all_pairs)
+
+
+@router.post("/{probe_set_id}/bulk-role")
+async def bulk_set_role(
+    probe_set_id: str, body: BulkRoleRequest, request: Request
+) -> ProbeSetDetail:
+    """Update role for specified pairs."""
+    conn = request.app.state.db
+    data_dir = request.app.state.config.data_dir
+    row = await db.get_probe_set(conn, probe_set_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Probe set not found")
+
+    pairs = _read_pairs(data_dir, probe_set_id)
+    target_ids = set(body.pair_ids)
+    for pair in pairs:
+        if pair.pair_id in target_ids:
+            pair.role = body.role
+
+    _write_pairs(data_dir, probe_set_id, pairs)
+
+    now = datetime.now(timezone.utc).isoformat()
+    await db.update_probe_set(conn, probe_set_id, updated_at=now)
+
+    updated_row = await db.get_probe_set(conn, probe_set_id)
+    return _make_detail(updated_row, pairs)

--- a/influence-workbench/backend/routes/tools.py
+++ b/influence-workbench/backend/routes/tools.py
@@ -1,0 +1,86 @@
+"""Tool endpoints: pretraining search, span extraction, context generation."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from backend.models import (
+    ExtractSpanRequest,
+    ExtractSpanResponse,
+    GenerateContextRequest,
+    GenerateContextResponse,
+    InfinigramDocument,
+    InfinigramDocSpan,
+    SearchPretrainingRequest,
+    SearchPretrainingResponse,
+)
+from backend.span import extract_span
+
+router = APIRouter(prefix="/api", tags=["tools"])
+
+
+@router.post("/search-pretraining")
+async def search_pretraining(
+    body: SearchPretrainingRequest, request: Request
+) -> SearchPretrainingResponse:
+    client = getattr(request.app.state, "infinigram_client", None)
+    if client is None:
+        raise HTTPException(status_code=503, detail="Infini-gram client not configured")
+
+    try:
+        result = await client.search(body.completion, max_docs=body.max_docs)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Infini-gram API error: {exc}")
+
+    documents = [
+        InfinigramDocument(
+            doc_ix=d["doc_ix"],
+            doc_len=d["doc_len"],
+            disp_len=d["disp_len"],
+            spans=[InfinigramDocSpan(**s) for s in d["spans"]],
+            full_text=d["full_text"],
+        )
+        for d in result["documents"]
+    ]
+    return SearchPretrainingResponse(
+        documents=documents,
+        query=result["query"],
+        count=result["count"],
+    )
+
+
+@router.post("/extract-span")
+async def extract_span_endpoint(body: ExtractSpanRequest) -> ExtractSpanResponse:
+    if body.match_start < 0 or body.match_end > len(body.document_text):
+        raise HTTPException(status_code=400, detail="match offsets out of range")
+    if body.match_start >= body.match_end:
+        raise HTTPException(status_code=400, detail="match_start must be < match_end")
+
+    prompt, completion = extract_span(
+        body.document_text,
+        body.match_start,
+        body.match_end,
+        span_length=body.span_length,
+    )
+    return ExtractSpanResponse(prompt=prompt, completion=completion)
+
+
+@router.post("/generate-context")
+async def generate_context(
+    body: GenerateContextRequest, request: Request
+) -> GenerateContextResponse:
+    client = getattr(request.app.state, "claude_client", None)
+    if client is None:
+        raise HTTPException(status_code=503, detail="Claude client not configured")
+
+    try:
+        generated = await client.generate_context(
+            body.completion, instruction=body.instruction
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Claude API error: {exc}")
+
+    return GenerateContextResponse(
+        generated_prompt=generated,
+        model=client.model,
+    )

--- a/influence-workbench/backend/span.py
+++ b/influence-workbench/backend/span.py
@@ -1,0 +1,59 @@
+"""Pure-function span extraction from document text."""
+
+from __future__ import annotations
+
+import re
+
+
+def _snap_to_sentence_start(text: str, pos: int) -> int:
+    """Move *pos* forward to the start of the next sentence if it's mid-sentence.
+
+    Looks for '. ', '! ', '? ' (or start-of-string) boundaries.
+    If no boundary is found, returns *pos* unchanged.
+    """
+    if pos == 0:
+        return 0
+    # Search forward from pos for sentence-start patterns
+    m = re.search(r"(?<=[.!?])\s+", text[pos:])
+    if m and m.start() < 60:
+        return pos + m.end()
+    return pos
+
+
+def extract_span(
+    document_text: str,
+    match_start: int,
+    match_end: int,
+    span_length: int = 256,
+) -> tuple[str, str]:
+    """Extract a (prompt, completion) pair from *document_text*.
+
+    Parameters
+    ----------
+    document_text:
+        Full text of the source document.
+    match_start:
+        Character offset where the matched completion begins.
+    match_end:
+        Character offset where the matched completion ends.
+    span_length:
+        Desired prompt length in characters (before the match).
+
+    Returns
+    -------
+    (prompt, completion) – The prompt is the text preceding the match,
+    snapped to sentence boundaries when possible.  The completion is
+    ``document_text[match_start:match_end]``.
+    """
+    completion = document_text[match_start:match_end]
+
+    raw_start = max(0, match_start - span_length)
+    # Snap to a sentence boundary (move forward to avoid partial sentences)
+    if raw_start > 0:
+        snapped = _snap_to_sentence_start(document_text, raw_start)
+        # Only snap if we still have meaningful prompt left
+        if snapped < match_start:
+            raw_start = snapped
+
+    prompt = document_text[raw_start:match_start]
+    return prompt, completion

--- a/influence-workbench/backend/tests/test_bulk_ops.py
+++ b/influence-workbench/backend/tests/test_bulk_ops.py
@@ -1,0 +1,110 @@
+"""Integration tests for import/duplicate/bulk-role endpoints."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+
+async def _create_probe_set(client, name="Test Set", pairs=None):
+    """Helper to create a probe set and return its id."""
+    if pairs is None:
+        pairs = [
+            {
+                "pair_id": "p1",
+                "prompt": "Hello",
+                "completion": "World",
+                "role": "both",
+                "metadata": {},
+            }
+        ]
+    resp = await client.post(
+        "/api/probe-sets",
+        json={"name": name, "pairs": pairs},
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def test_import_pairs_json(client):
+    ps_id = await _create_probe_set(client)
+
+    import_data = [
+        {"pair_id": "imp1", "prompt": "A", "completion": "B", "role": "train"},
+        {"pair_id": "imp2", "prompt": "C", "completion": "D", "role": "query"},
+    ]
+    content = json.dumps(import_data).encode()
+
+    resp = await client.post(
+        f"/api/probe-sets/{ps_id}/import-pairs",
+        files={"file": ("pairs.json", content, "application/json")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pair_count"] == 3  # 1 existing + 2 imported
+    pair_ids = [p["pair_id"] for p in data["pairs"]]
+    assert "p1" in pair_ids
+    assert "imp1" in pair_ids
+    assert "imp2" in pair_ids
+
+
+async def test_import_pairs_csv(client):
+    ps_id = await _create_probe_set(client)
+
+    csv_content = "pair_id,prompt,completion,role\ncsv1,Hello,World,train\ncsv2,Foo,Bar,both\n"
+
+    resp = await client.post(
+        f"/api/probe-sets/{ps_id}/import-pairs",
+        files={"file": ("pairs.csv", csv_content.encode(), "text/csv")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pair_count"] == 3  # 1 existing + 2 imported
+
+
+async def test_import_pairs_invalid_json(client):
+    ps_id = await _create_probe_set(client)
+
+    resp = await client.post(
+        f"/api/probe-sets/{ps_id}/import-pairs",
+        files={"file": ("bad.json", b"not json", "application/json")},
+    )
+    assert resp.status_code == 400
+
+
+async def test_import_pairs_not_found(client):
+    resp = await client.post(
+        "/api/probe-sets/nonexistent/import-pairs",
+        files={"file": ("pairs.json", b"[]", "application/json")},
+    )
+    assert resp.status_code == 404
+
+
+async def test_bulk_role(client):
+    pairs = [
+        {"pair_id": "a", "prompt": "P1", "completion": "C1", "role": "both", "metadata": {}},
+        {"pair_id": "b", "prompt": "P2", "completion": "C2", "role": "both", "metadata": {}},
+        {"pair_id": "c", "prompt": "P3", "completion": "C3", "role": "both", "metadata": {}},
+    ]
+    ps_id = await _create_probe_set(client, pairs=pairs)
+
+    resp = await client.post(
+        f"/api/probe-sets/{ps_id}/bulk-role",
+        json={"pair_ids": ["a", "c"], "role": "train"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    roles_by_id = {p["pair_id"]: p["role"] for p in data["pairs"]}
+    assert roles_by_id["a"] == "train"
+    assert roles_by_id["b"] == "both"  # unchanged
+    assert roles_by_id["c"] == "train"
+
+
+async def test_bulk_role_not_found(client):
+    resp = await client.post(
+        "/api/probe-sets/nonexistent/bulk-role",
+        json={"pair_ids": ["a"], "role": "train"},
+    )
+    assert resp.status_code == 404

--- a/influence-workbench/backend/tests/test_span.py
+++ b/influence-workbench/backend/tests/test_span.py
@@ -1,0 +1,61 @@
+"""Unit tests for span extraction."""
+
+from __future__ import annotations
+
+from backend.span import extract_span
+
+
+def test_basic_extraction():
+    text = "The quick brown fox jumps over the lazy dog."
+    prompt, completion = extract_span(text, 16, 25, span_length=16)
+    assert completion == "fox jumps"
+    assert prompt == text[:16]
+
+
+def test_match_at_start():
+    text = "Hello world. This is a test."
+    prompt, completion = extract_span(text, 0, 5, span_length=100)
+    assert completion == "Hello"
+    assert prompt == ""
+
+
+def test_match_at_end():
+    text = "First sentence. Second sentence. Final word."
+    match_start = len(text) - 11  # "Final word."
+    match_end = len(text)
+    prompt, completion = extract_span(text, match_start, match_end, span_length=100)
+    assert completion == "Final word."
+    assert len(prompt) > 0
+
+
+def test_span_larger_than_document():
+    text = "Short text."
+    prompt, completion = extract_span(text, 6, 11, span_length=1000)
+    assert completion == "text."
+    assert prompt == "Short "
+
+
+def test_sentence_snapping():
+    text = "First sentence. Second sentence. Third sentence. The match here."
+    # match_start is at "The match here."
+    match_start = text.index("The match here.")
+    match_end = len(text)
+    # Use a span_length that puts raw_start mid-sentence
+    prompt, completion = extract_span(text, match_start, match_end, span_length=30)
+    assert completion == "The match here."
+    # Prompt should snap to a sentence boundary
+    assert not prompt or prompt[0].isupper() or prompt.startswith(" ")
+
+
+def test_zero_span_length():
+    text = "Hello world."
+    prompt, completion = extract_span(text, 6, 12, span_length=0)
+    assert completion == "world."
+    assert prompt == ""
+
+
+def test_exact_match_boundaries():
+    text = "ABCDEFGHIJ"
+    prompt, completion = extract_span(text, 5, 10, span_length=5)
+    assert completion == "FGHIJ"
+    assert prompt == "ABCDE"

--- a/influence-workbench/backend/tests/test_tools.py
+++ b/influence-workbench/backend/tests/test_tools.py
@@ -1,0 +1,111 @@
+"""Integration tests for tool endpoints (mocked external APIs)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def test_search_pretraining(client):
+    resp = await client.post(
+        "/api/search-pretraining",
+        json={"completion": "matched text", "max_docs": 5},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["query"] == "matched text"
+    assert data["count"] == 100
+    assert len(data["documents"]) == 1
+    doc = data["documents"][0]
+    assert doc["doc_ix"] == 42
+    assert len(doc["spans"]) == 3
+    assert doc["spans"][1]["is_match"] is True
+    assert doc["full_text"] == "Before the matched text after."
+
+
+async def test_search_pretraining_no_client(client, app):
+    app.state.infinigram_client = None
+    resp = await client.post(
+        "/api/search-pretraining",
+        json={"completion": "test"},
+    )
+    assert resp.status_code == 503
+
+
+async def test_extract_span(client):
+    text = "First sentence. Second sentence. The target completion here."
+    match_start = text.index("The target")
+    match_end = len(text)
+    resp = await client.post(
+        "/api/extract-span",
+        json={
+            "document_text": text,
+            "match_start": match_start,
+            "match_end": match_end,
+            "span_length": 256,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["completion"] == "The target completion here."
+    assert len(data["prompt"]) > 0
+
+
+async def test_extract_span_invalid_offsets(client):
+    resp = await client.post(
+        "/api/extract-span",
+        json={
+            "document_text": "short",
+            "match_start": 10,
+            "match_end": 20,
+            "span_length": 100,
+        },
+    )
+    assert resp.status_code == 400
+
+
+async def test_extract_span_start_ge_end(client):
+    resp = await client.post(
+        "/api/extract-span",
+        json={
+            "document_text": "some text",
+            "match_start": 5,
+            "match_end": 5,
+            "span_length": 100,
+        },
+    )
+    assert resp.status_code == 400
+
+
+async def test_generate_context(client):
+    resp = await client.post(
+        "/api/generate-context",
+        json={"completion": "the answer is 42"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["generated_prompt"] == "This is a generated context prompt."
+    assert data["model"] == "claude-haiku-4-5-20251001"
+
+
+async def test_generate_context_with_instruction(client, app):
+    resp = await client.post(
+        "/api/generate-context",
+        json={
+            "completion": "the answer is 42",
+            "instruction": "Write as a Wikipedia article",
+        },
+    )
+    assert resp.status_code == 200
+    # Verify the mock was called with instruction
+    app.state.claude_client.generate_context.assert_called_with(
+        "the answer is 42", instruction="Write as a Wikipedia article"
+    )
+
+
+async def test_generate_context_no_client(client, app):
+    app.state.claude_client = None
+    resp = await client.post(
+        "/api/generate-context",
+        json={"completion": "test"},
+    )
+    assert resp.status_code == 503

--- a/influence-workbench/config.yaml
+++ b/influence-workbench/config.yaml
@@ -1,9 +1,13 @@
 model: "allenai/OLMo-2-1124-13B"
 revision: "stage1-step596057-tokens5001B"
 factors_dir: "/home/developer/hessian_output"
-query_batch_size: 8
-train_batch_size: 8
+query_batch_size: 4
+train_batch_size: 2
 max_concurrent_runs: 1
 max_length: 512
 if_query_dir: "../if-query"
 data_dir: "data"
+infinigram_api_url: "https://api.infini-gram.io/"
+infinigram_index: "v4_olmo-mix-1124_llama"
+infinigram_max_docs: 10
+claude_model: "claude-haiku-4-5-20251001"

--- a/influence-workbench/frontend/src/lib/components/BulkImportModal.svelte
+++ b/influence-workbench/frontend/src/lib/components/BulkImportModal.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+	import Modal from './Modal.svelte';
+	import * as api from '$lib/api';
+	import type { Pair, ProbeSetDetail } from '$lib/types';
+
+	let {
+		open = false,
+		probeSetId = '',
+		onclose,
+		onimport
+	}: {
+		open: boolean;
+		probeSetId: string;
+		onclose: () => void;
+		onimport: (detail: ProbeSetDetail) => void;
+	} = $props();
+
+	let file = $state<File | null>(null);
+	let previewPairs = $state<Array<{ pair_id: string; prompt: string; completion: string; role: string }>>([]);
+	let importing = $state(false);
+	let importError = $state('');
+
+	function onFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		file = input.files?.[0] ?? null;
+		previewPairs = [];
+		importError = '';
+		if (file) {
+			parsePreview(file);
+		}
+	}
+
+	async function parsePreview(f: File) {
+		const text = await f.text();
+		try {
+			if (f.name.endsWith('.json')) {
+				const data = JSON.parse(text);
+				if (!Array.isArray(data)) throw new Error('JSON must be an array');
+				previewPairs = data.slice(0, 20).map((d: Record<string, string>) => ({
+					pair_id: d.pair_id || '',
+					prompt: d.prompt || '',
+					completion: d.completion || '',
+					role: d.role || 'both'
+				}));
+			} else {
+				// CSV
+				const lines = text.trim().split('\n');
+				if (lines.length < 2) throw new Error('CSV must have a header and at least one row');
+				const headers = lines[0].split(',').map((h) => h.trim());
+				previewPairs = lines
+					.slice(1, 21)
+					.map((line) => {
+						const vals = line.split(',').map((v) => v.trim());
+						const obj: Record<string, string> = {};
+						headers.forEach((h, i) => (obj[h] = vals[i] || ''));
+						return {
+							pair_id: obj.pair_id || '',
+							prompt: obj.prompt || '',
+							completion: obj.completion || '',
+							role: obj.role || 'both'
+						};
+					});
+			}
+		} catch (e) {
+			importError = `Preview error: ${e}`;
+		}
+	}
+
+	async function doImport() {
+		if (!file || !probeSetId) return;
+		importing = true;
+		importError = '';
+		try {
+			const detail = await api.importPairs(probeSetId, file);
+			onimport(detail);
+			onclose();
+		} catch (e) {
+			importError = String(e);
+		} finally {
+			importing = false;
+		}
+	}
+</script>
+
+<Modal title="Import Pairs" {open} {onclose}>
+	<div class="import-section">
+		<div class="field-group">
+			<label for="file-input">Select CSV or JSON file</label>
+			<input
+				id="file-input"
+				type="file"
+				accept=".csv,.json"
+				onchange={onFileChange}
+			/>
+		</div>
+
+		{#if importError}
+			<div class="error">{importError}</div>
+		{/if}
+
+		{#if previewPairs.length > 0}
+			<div class="preview">
+				<h4>Preview ({previewPairs.length} pairs{file && previewPairs.length >= 20 ? ', showing first 20' : ''})</h4>
+				<div class="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th>ID</th>
+								<th>Prompt</th>
+								<th>Completion</th>
+								<th>Role</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each previewPairs as p}
+								<tr>
+									<td>{p.pair_id}</td>
+									<td class="truncate">{p.prompt}</td>
+									<td class="truncate">{p.completion}</td>
+									<td>{p.role}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+
+			<button class="primary" onclick={doImport} disabled={importing}>
+				{importing ? 'Importing...' : 'Import'}
+			</button>
+		{/if}
+	</div>
+</Modal>
+
+<style>
+	.import-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	.field-group label {
+		font-size: 0.8rem;
+		color: var(--text-muted, #888);
+	}
+	.preview h4 {
+		font-size: 0.9rem;
+		margin-bottom: 0.5rem;
+	}
+	.table-wrap {
+		max-height: 300px;
+		overflow: auto;
+	}
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.825rem;
+	}
+	th,
+	td {
+		border: 1px solid var(--border, #ddd);
+		padding: 0.35rem 0.5rem;
+		text-align: left;
+	}
+	th {
+		background: var(--surface, #f5f5f5);
+		font-weight: 600;
+	}
+	.truncate {
+		max-width: 180px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.error {
+		background: rgba(239, 83, 80, 0.1);
+		border: 1px solid var(--danger, #ef5350);
+		padding: 0.5rem 0.75rem;
+		border-radius: 4px;
+		font-size: 0.875rem;
+	}
+</style>

--- a/influence-workbench/frontend/src/lib/components/GenerateContextModal.svelte
+++ b/influence-workbench/frontend/src/lib/components/GenerateContextModal.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import Modal from './Modal.svelte';
+	import * as api from '$lib/api';
+
+	let {
+		open = false,
+		onclose,
+		onuse
+	}: {
+		open: boolean;
+		onclose: () => void;
+		onuse: (prompt: string, completion: string) => void;
+	} = $props();
+
+	let completion = $state('');
+	let instruction = $state('');
+	let generating = $state(false);
+	let generatedPrompt = $state('');
+	let modelUsed = $state('');
+	let genError = $state('');
+	let editing = $state(false);
+	let editText = $state('');
+
+	async function generate() {
+		if (!completion.trim()) return;
+		generating = true;
+		genError = '';
+		editing = false;
+		try {
+			const result = await api.generateContext(
+				completion,
+				instruction.trim() || undefined
+			);
+			generatedPrompt = result.generated_prompt;
+			modelUsed = result.model;
+		} catch (e) {
+			genError = String(e);
+		} finally {
+			generating = false;
+		}
+	}
+
+	function accept() {
+		const text = editing ? editText : generatedPrompt;
+		onuse(text, completion);
+		onclose();
+	}
+
+	function startEdit() {
+		editText = generatedPrompt;
+		editing = true;
+	}
+</script>
+
+<Modal title="Generate Context" {open} {onclose}>
+	<div class="gen-section">
+		<div class="field-group">
+			<label for="gen-completion">Completion text</label>
+			<textarea
+				id="gen-completion"
+				bind:value={completion}
+				placeholder="Enter the completion text you want context for..."
+				rows="3"
+			></textarea>
+		</div>
+
+		<div class="field-group">
+			<label for="gen-instruction">Instruction (optional)</label>
+			<textarea
+				id="gen-instruction"
+				bind:value={instruction}
+				placeholder="e.g., Write as a Wikipedia article"
+				rows="2"
+			></textarea>
+		</div>
+
+		<button class="primary" onclick={generate} disabled={generating || !completion.trim()}>
+			{generating ? 'Generating...' : generatedPrompt ? 'Regenerate' : 'Generate'}
+		</button>
+
+		{#if genError}
+			<div class="error">{genError}</div>
+		{/if}
+
+		{#if generatedPrompt && !generating}
+			<div class="result">
+				<div class="field-group">
+					<label>Generated prompt {modelUsed ? `(${modelUsed})` : ''}</label>
+					{#if editing}
+						<textarea
+							bind:value={editText}
+							rows="6"
+						></textarea>
+					{:else}
+						<div class="result-text">{generatedPrompt}</div>
+					{/if}
+				</div>
+				<div class="result-actions">
+					<button class="primary" onclick={accept}>Accept</button>
+					<button onclick={generate}>Regenerate</button>
+					{#if !editing}
+						<button onclick={startEdit}>Edit</button>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</div>
+</Modal>
+
+<style>
+	.gen-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	.field-group label {
+		font-size: 0.8rem;
+		color: var(--text-muted, #888);
+	}
+	.result {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.result-text {
+		font-size: 0.875rem;
+		padding: 0.75rem;
+		border: 1px solid var(--border, #ddd);
+		border-radius: 4px;
+		max-height: 200px;
+		overflow-y: auto;
+		white-space: pre-wrap;
+		line-height: 1.5;
+	}
+	.result-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+	textarea {
+		resize: vertical;
+		min-height: 48px;
+	}
+	.error {
+		background: rgba(239, 83, 80, 0.1);
+		border: 1px solid var(--danger, #ef5350);
+		padding: 0.5rem 0.75rem;
+		border-radius: 4px;
+		font-size: 0.875rem;
+	}
+</style>

--- a/influence-workbench/frontend/src/lib/components/Modal.svelte
+++ b/influence-workbench/frontend/src/lib/components/Modal.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		title,
+		open = false,
+		onclose,
+		children
+	}: {
+		title: string;
+		open: boolean;
+		onclose: () => void;
+		children: Snippet;
+	} = $props();
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+	}
+
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) onclose();
+	}
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div class="modal-backdrop" role="dialog" aria-modal="true" aria-label={title} onclick={handleBackdropClick} onkeydown={handleKeydown}>
+		<div class="modal-card">
+			<div class="modal-header">
+				<h3>{title}</h3>
+				<button class="close-btn" onclick={onclose}>&times;</button>
+			</div>
+			<div class="modal-body">
+				{@render children()}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+	.modal-card {
+		background: var(--bg, #fff);
+		border-radius: 8px;
+		width: 90vw;
+		max-width: 720px;
+		max-height: 80vh;
+		display: flex;
+		flex-direction: column;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+	}
+	.modal-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 1rem 1.25rem;
+		border-bottom: 1px solid var(--border, #ddd);
+	}
+	.modal-header h3 {
+		margin: 0;
+		font-size: 1rem;
+	}
+	.close-btn {
+		background: none;
+		border: none;
+		font-size: 1.5rem;
+		cursor: pointer;
+		padding: 0 0.25rem;
+		line-height: 1;
+		color: var(--text-muted, #888);
+	}
+	.modal-body {
+		padding: 1.25rem;
+		overflow-y: auto;
+	}
+</style>

--- a/influence-workbench/frontend/src/lib/components/SearchPretrainingModal.svelte
+++ b/influence-workbench/frontend/src/lib/components/SearchPretrainingModal.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+	import Modal from './Modal.svelte';
+	import * as api from '$lib/api';
+	import type { InfinigramDocument, ExtractSpanResponse } from '$lib/types';
+
+	let {
+		open = false,
+		onclose,
+		onuse
+	}: {
+		open: boolean;
+		onclose: () => void;
+		onuse: (pairs: Array<{ prompt: string; completion: string }>) => void;
+	} = $props();
+
+	let searchQuery = $state('');
+	let maxResults = $state(5);
+	let searching = $state(false);
+	let documents = $state<InfinigramDocument[]>([]);
+	let totalCount = $state(0);
+	let searchError = $state('');
+
+	// Multi-select for batch add
+	let checkedDocs = $state<Set<number>>(new Set());
+	let spanLength = $state(256);
+	let adding = $state(false);
+
+	// Single-doc preview
+	let previewDoc = $state<InfinigramDocument | null>(null);
+	let extractedPrompt = $state('');
+	let extractedCompletion = $state('');
+	let extracting = $state(false);
+
+	async function doSearch() {
+		if (!searchQuery.trim()) return;
+		searching = true;
+		searchError = '';
+		documents = [];
+		checkedDocs = new Set();
+		previewDoc = null;
+		try {
+			const result = await api.searchPretraining(searchQuery, maxResults);
+			documents = result.documents;
+			totalCount = result.count;
+		} catch (e) {
+			searchError = String(e);
+		} finally {
+			searching = false;
+		}
+	}
+
+	function toggleDoc(index: number) {
+		const next = new Set(checkedDocs);
+		if (next.has(index)) {
+			next.delete(index);
+		} else {
+			next.add(index);
+		}
+		checkedDocs = next;
+	}
+
+	function getMatchOffsets(doc: InfinigramDocument): { start: number; end: number } {
+		let offset = 0;
+		for (const span of doc.spans) {
+			if (span.is_match) {
+				return { start: offset, end: offset + span.text.length };
+			}
+			offset += span.text.length;
+		}
+		return { start: 0, end: 0 };
+	}
+
+	async function addCheckedPairs() {
+		if (checkedDocs.size === 0) return;
+		adding = true;
+		searchError = '';
+		try {
+			const extractions = await Promise.all(
+				[...checkedDocs].map(async (idx) => {
+					const doc = documents[idx];
+					const { start, end } = getMatchOffsets(doc);
+					if (start === end) return null;
+					return api.extractSpan(doc.full_text, start, end, spanLength);
+				})
+			);
+			const pairs = extractions
+				.filter((e): e is ExtractSpanResponse => e !== null)
+				.map((e) => ({ prompt: e.prompt, completion: e.completion }));
+			if (pairs.length > 0) {
+				onuse(pairs);
+				onclose();
+			}
+		} catch (e) {
+			searchError = String(e);
+		} finally {
+			adding = false;
+		}
+	}
+
+	// Single-doc preview
+	async function previewDocument(doc: InfinigramDocument) {
+		previewDoc = doc;
+		await extractPreview();
+	}
+
+	async function extractPreview() {
+		if (!previewDoc) return;
+		const { start, end } = getMatchOffsets(previewDoc);
+		if (start === end) return;
+		extracting = true;
+		try {
+			const result = await api.extractSpan(previewDoc.full_text, start, end, spanLength);
+			extractedPrompt = result.prompt;
+			extractedCompletion = result.completion;
+		} catch (e) {
+			searchError = String(e);
+		} finally {
+			extracting = false;
+		}
+	}
+
+	function usePreviewPair() {
+		onuse([{ prompt: extractedPrompt, completion: extractedCompletion }]);
+		onclose();
+	}
+
+	let spanTimer: ReturnType<typeof setTimeout>;
+	function onSpanChange() {
+		clearTimeout(spanTimer);
+		spanTimer = setTimeout(() => {
+			if (previewDoc) extractPreview();
+		}, 300);
+	}
+</script>
+
+<Modal title="Search Pretraining Data" {open} {onclose}>
+	<div class="search-section">
+		<div class="search-bar">
+			<input
+				bind:value={searchQuery}
+				placeholder="Search completion text..."
+				onkeydown={(e) => e.key === 'Enter' && doSearch()}
+			/>
+			<label class="max-results-label">
+				Max
+				<input
+					type="number"
+					min="1"
+					max="10"
+					bind:value={maxResults}
+					class="max-results"
+				/>
+			</label>
+			<button class="primary" onclick={doSearch} disabled={searching || !searchQuery.trim()}>
+				{searching ? 'Searching...' : 'Search'}
+			</button>
+		</div>
+
+		{#if searchError}
+			<div class="error">{searchError}</div>
+		{/if}
+
+		{#if totalCount > 0}
+			<div class="result-count">{totalCount.toLocaleString()} corpus matches</div>
+		{/if}
+
+		{#if documents.length > 0 && !previewDoc}
+			<div class="span-control">
+				<label>
+					Prompt length: {spanLength} chars
+					<input
+						type="range"
+						min="64"
+						max="1024"
+						step="32"
+						bind:value={spanLength}
+						oninput={onSpanChange}
+					/>
+				</label>
+			</div>
+
+			<div class="doc-list">
+				{#each documents as doc, i}
+					<div class="doc-item" class:checked={checkedDocs.has(i)}>
+						<label class="doc-check">
+							<input
+								type="checkbox"
+								checked={checkedDocs.has(i)}
+								onchange={() => toggleDoc(i)}
+							/>
+						</label>
+						<button class="doc-content" onclick={() => previewDocument(doc)}>
+							<div class="doc-header">Document {i + 1} (len: {doc.doc_len})</div>
+							<div class="doc-preview">
+								{#each doc.spans as span}
+									{#if span.is_match}<mark>{span.text}</mark>{:else}{span.text}{/if}
+								{/each}
+							</div>
+						</button>
+					</div>
+				{/each}
+			</div>
+
+			{#if checkedDocs.size > 0}
+				<button class="primary" onclick={addCheckedPairs} disabled={adding}>
+					{adding ? 'Extracting...' : `Add ${checkedDocs.size} pair${checkedDocs.size > 1 ? 's' : ''}`}
+				</button>
+			{/if}
+		{/if}
+
+		{#if previewDoc}
+			<div class="selected-doc">
+				<button class="back-btn" onclick={() => { previewDoc = null; }}>
+					Back to results
+				</button>
+
+				<div class="doc-text">
+					{#each previewDoc.spans as span}
+						{#if span.is_match}<mark>{span.text}</mark>{:else}{span.text}{/if}
+					{/each}
+				</div>
+
+				<div class="span-control">
+					<label>
+						Prompt length: {spanLength} chars
+						<input
+							type="range"
+							min="64"
+							max="1024"
+							step="32"
+							bind:value={spanLength}
+							oninput={onSpanChange}
+						/>
+					</label>
+				</div>
+
+				{#if extracting}
+					<div class="loading">Extracting span...</div>
+				{:else if extractedPrompt || extractedCompletion}
+					<div class="extracted">
+						<div class="field-group">
+							<label>Prompt</label>
+							<div class="preview-text">{extractedPrompt}</div>
+						</div>
+						<div class="field-group">
+							<label>Completion</label>
+							<div class="preview-text completion">{extractedCompletion}</div>
+						</div>
+						<button class="primary" onclick={usePreviewPair}>Add this pair</button>
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+</Modal>
+
+<style>
+	.search-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.search-bar {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+	.search-bar > input:first-child {
+		flex: 1;
+	}
+	.max-results-label {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.8rem;
+		color: var(--text-muted, #888);
+		white-space: nowrap;
+	}
+	.max-results {
+		width: 50px;
+	}
+	.result-count {
+		font-size: 0.85rem;
+		color: var(--text-muted, #888);
+	}
+	.doc-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-height: 300px;
+		overflow-y: auto;
+	}
+	.doc-item {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.5rem;
+		padding: 0.5rem;
+		border: 1px solid var(--border, #ddd);
+		border-radius: 6px;
+	}
+	.doc-item.checked {
+		border-color: var(--primary, #1976d2);
+		background: rgba(25, 118, 210, 0.04);
+	}
+	.doc-check {
+		padding-top: 0.25rem;
+		cursor: pointer;
+	}
+	.doc-content {
+		flex: 1;
+		text-align: left;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0.25rem 0;
+	}
+	.doc-content:hover {
+		background: var(--surface, #f5f5f5);
+		border-radius: 4px;
+	}
+	.doc-header {
+		font-size: 0.8rem;
+		color: var(--text-muted, #888);
+		margin-bottom: 0.25rem;
+	}
+	.doc-preview {
+		font-size: 0.875rem;
+		line-height: 1.4;
+		max-height: 4em;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	mark {
+		background: #fff3cd;
+		padding: 0 2px;
+		border-radius: 2px;
+	}
+	.selected-doc {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.back-btn {
+		align-self: flex-start;
+		font-size: 0.85rem;
+	}
+	.doc-text {
+		font-size: 0.875rem;
+		line-height: 1.5;
+		max-height: 150px;
+		overflow-y: auto;
+		padding: 0.75rem;
+		border: 1px solid var(--border, #ddd);
+		border-radius: 4px;
+	}
+	.span-control {
+		display: flex;
+		align-items: center;
+	}
+	.span-control label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.85rem;
+	}
+	.span-control input[type='range'] {
+		width: 200px;
+	}
+	.loading {
+		font-size: 0.85rem;
+		color: var(--text-muted, #888);
+	}
+	.extracted {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.field-group label {
+		font-size: 0.8rem;
+		color: var(--text-muted, #888);
+	}
+	.preview-text {
+		font-size: 0.875rem;
+		padding: 0.5rem;
+		border: 1px solid var(--border, #ddd);
+		border-radius: 4px;
+		max-height: 80px;
+		overflow-y: auto;
+		white-space: pre-wrap;
+	}
+	.preview-text.completion {
+		background: #f0f9ff;
+	}
+	.error {
+		background: rgba(239, 83, 80, 0.1);
+		border: 1px solid var(--danger, #ef5350);
+		padding: 0.5rem 0.75rem;
+		border-radius: 4px;
+		font-size: 0.875rem;
+	}
+</style>

--- a/influence-workbench/frontend/src/lib/types.ts
+++ b/influence-workbench/frontend/src/lib/types.ts
@@ -50,3 +50,38 @@ export interface InfluenceRow {
 	influence_score: number;
 	per_token_scores: string | null;
 }
+
+// Tool types — Infini-gram search
+
+export interface InfinigramDocSpan {
+	text: string;
+	is_match: boolean;
+}
+
+export interface InfinigramDocument {
+	doc_ix: number;
+	doc_len: number;
+	disp_len: number;
+	spans: InfinigramDocSpan[];
+	full_text: string;
+}
+
+export interface SearchPretrainingResponse {
+	documents: InfinigramDocument[];
+	query: string;
+	count: number;
+}
+
+// Tool types — Span extraction
+
+export interface ExtractSpanResponse {
+	prompt: string;
+	completion: string;
+}
+
+// Tool types — Claude context generation
+
+export interface GenerateContextResponse {
+	generated_prompt: string;
+	model: string;
+}

--- a/influence-workbench/pyproject.toml
+++ b/influence-workbench/pyproject.toml
@@ -14,13 +14,15 @@ dependencies = [
     "aiosqlite>=0.19.0",
     "pyyaml>=6.0",
     "websockets>=12.0",
+    "httpx>=0.25.0",
+    "anthropic>=0.40.0",
+    "python-multipart>=0.0.6",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.23.0",
-    "httpx>=0.25.0",
 ]
 
 [tool.pytest.ini_options]

--- a/influence-workbench/uv.lock
+++ b/influence-workbench/uv.lock
@@ -30,6 +30,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/e5/02cd2919ec327b24234abb73082e6ab84c451182cc3cc60681af700f4c63/anthropic-0.83.0.tar.gz", hash = "sha256:a8732c68b41869266c3034541a31a29d8be0f8cd0a714f9edce3128b351eceb4", size = 534058, upload-time = "2026-02-19T19:26:38.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/75/b9d58e4e2a4b1fc3e75ffbab978f999baf8b7c4ba9f96e60edb918ba386b/anthropic-0.83.0-py3-none-any.whl", hash = "sha256:f069ef508c73b8f9152e8850830d92bd5ef185645dbacf234bb213344a274810", size = 456991, upload-time = "2026-02-19T19:26:40.114Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -80,6 +99,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -205,8 +242,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "anthropic" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
@@ -214,7 +254,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -222,11 +261,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
+    { name = "anthropic", specifier = ">=0.40.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.25.0" },
+    { name = "httpx", specifier = ">=0.25.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
     { name = "websockets", specifier = ">=12.0" },
@@ -240,6 +281,103 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/5a/41da76c5ea07bec1b0472b6b2fdb1b651074d504b19374d7e130e0cdfb25/jiter-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ffc63785fd6c7977defe49b9824ae6ce2b2e2b77ce539bdaf006c26da06342e", size = 311164, upload-time = "2026-02-02T12:35:17.688Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cb/4a1bf994a3e869f0d39d10e11efb471b76d0ad70ecbfb591427a46c880c2/jiter-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4a638816427006c1e3f0013eb66d391d7a3acda99a7b0cf091eff4497ccea33a", size = 320296, upload-time = "2026-02-02T12:35:19.828Z" },
+    { url = "https://files.pythonhosted.org/packages/09/82/acd71ca9b50ecebadc3979c541cd717cce2fe2bc86236f4fa597565d8f1a/jiter-0.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19928b5d1ce0ff8c1ee1b9bdef3b5bfc19e8304f1b904e436caf30bc15dc6cf5", size = 352742, upload-time = "2026-02-02T12:35:21.258Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/d1fc996f3aecfd42eb70922edecfb6dd26421c874503e241153ad41df94f/jiter-0.13.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:309549b778b949d731a2f0e1594a3f805716be704a73bf3ad9a807eed5eb5721", size = 363145, upload-time = "2026-02-02T12:35:24.653Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/61/a30492366378cc7a93088858f8991acd7d959759fe6138c12a4644e58e81/jiter-0.13.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcdabaea26cb04e25df3103ce47f97466627999260290349a88c8136ecae0060", size = 487683, upload-time = "2026-02-02T12:35:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4e/4223cffa9dbbbc96ed821c5aeb6bca510848c72c02086d1ed3f1da3d58a7/jiter-0.13.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a377af27b236abbf665a69b2bdd680e3b5a0bd2af825cd3b81245279a7606c", size = 373579, upload-time = "2026-02-02T12:35:27.582Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c9/b0489a01329ab07a83812d9ebcffe7820a38163c6d9e7da644f926ff877c/jiter-0.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe49d3ff6db74321f144dff9addd4a5874d3105ac5ba7c5b77fac099cfae31ae", size = 362904, upload-time = "2026-02-02T12:35:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/05/af/53e561352a44afcba9a9bc67ee1d320b05a370aed8df54eafe714c4e454d/jiter-0.13.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2113c17c9a67071b0f820733c0893ed1d467b5fcf4414068169e5c2cabddb1e2", size = 392380, upload-time = "2026-02-02T12:35:30.385Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2a/dd805c3afb8ed5b326c5ae49e725d1b1255b9754b1b77dbecdc621b20773/jiter-0.13.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab1185ca5c8b9491b55ebf6c1e8866b8f68258612899693e24a92c5fdb9455d5", size = 517939, upload-time = "2026-02-02T12:35:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/7b67d76f55b8fe14c937e7640389612f05f9a4145fc28ae128aaa5e62257/jiter-0.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9621ca242547edc16400981ca3231e0c91c0c4c1ab8573a596cd9bb3575d5c2b", size = 551696, upload-time = "2026-02-02T12:35:33.306Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9c/57cdd64dac8f4c6ab8f994fe0eb04dc9fd1db102856a4458fcf8a99dfa62/jiter-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a7637d92b1c9d7a771e8c56f445c7f84396d48f2e756e5978840ecba2fac0894", size = 204592, upload-time = "2026-02-02T12:35:34.58Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/38/f4f3ea5788b8a5bae7510a678cdc747eda0c45ffe534f9878ff37e7cf3b3/jiter-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c1b609e5cbd2f52bb74fb721515745b407df26d7b800458bd97cb3b972c29e7d", size = 206016, upload-time = "2026-02-02T12:35:36.435Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -444,6 +582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -505,6 +652,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Infini-gram pretraining search**: Search OLMo pretraining data via the infini-gram `search_docs` API with multi-document selection and batch span extraction
- **Claude context generation**: Generate prompt context for a given completion using Claude, with edit/regenerate support
- **Bulk pair operations**: CSV/JSON import, per-pair duplicate, and bulk role assignment across selected pairs
- **Standalone toolbar tools**: Search and generate are detached from individual pairs — they append new pairs to the list

## Known limitations

- Infini-gram `search_docs` API has a hard limit of 10 results per query (see #8)

## Test plan

- [x] 68 backend tests pass (`uv run pytest`)
- [x] 0 TypeScript errors (`npm run check`)
- [ ] Manual: search pretraining → check multiple docs → "Add N pairs" appends correctly
- [ ] Manual: generate context → type completion → accept → new pair appended
- [ ] Manual: CSV/JSON import adds pairs to existing probe set
- [ ] Manual: bulk role assignment updates selected pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)