### PR TITLE
Fix infini-gram search limit with repeated calls and dedup

### DIFF
--- a/influence-workbench/backend/app.py
+++ b/influence-workbench/backend/app.py
@@ -38,6 +38,7 @@ async def lifespan(app: FastAPI):
         http_client=http_client,
         api_url=config.infinigram_api_url,
         index=config.infinigram_index,
+        max_attempts=config.infinigram_max_attempts,
     )
     app.state.claude_client = ClaudeClient(model=config.claude_model)
 

--- a/influence-workbench/backend/clients/infinigram.py
+++ b/influence-workbench/backend/clients/infinigram.py
@@ -5,14 +5,21 @@ from __future__ import annotations
 import httpx
 
 API_PAGE_SIZE = 10  # Hard server-side limit for search_docs maxnum
-MAX_ATTEMPTS = 10  # Cap on API calls to avoid infinite loops
+DEFAULT_MAX_ATTEMPTS = 10  # Default cap on API calls to avoid infinite loops
 
 
 class InfinigramClient:
-    def __init__(self, http_client: httpx.AsyncClient, api_url: str, index: str):
+    def __init__(
+        self,
+        http_client: httpx.AsyncClient,
+        api_url: str,
+        index: str,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    ):
         self._http = http_client
         self._api_url = api_url.rstrip("/")
         self._index = index
+        self._max_attempts = max_attempts
 
     async def _post(self, payload: dict) -> dict:
         resp = await self._http.post(self._api_url, json=payload, timeout=30.0)
@@ -56,7 +63,7 @@ class InfinigramClient:
 
         page_size = min(max_docs, API_PAGE_SIZE)
 
-        for _ in range(MAX_ATTEMPTS):
+        for _ in range(self._max_attempts):
             if len(collected) >= max_docs:
                 break
 

--- a/influence-workbench/backend/clients/infinigram.py
+++ b/influence-workbench/backend/clients/infinigram.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import httpx
 
+API_PAGE_SIZE = 10  # Hard server-side limit for search_docs maxnum
+MAX_ATTEMPTS = 10  # Cap on API calls to avoid infinite loops
+
 
 class InfinigramClient:
     def __init__(self, http_client: httpx.AsyncClient, api_url: str, index: str):
@@ -16,51 +19,80 @@ class InfinigramClient:
         resp.raise_for_status()
         return resp.json()
 
-    async def search(self, query: str, max_docs: int = 10) -> dict:
-        """Search for *query* and return matching documents.
+    def _parse_document(self, doc: dict) -> dict:
+        """Parse a raw API document into our internal format."""
+        raw_spans = doc.get("spans", [])
+        doc_spans = []
+        for span in raw_spans:
+            if isinstance(span, list) and len(span) >= 2:
+                doc_spans.append(
+                    {
+                        "text": span[0],
+                        "is_match": span[1] is not None,
+                    }
+                )
 
-        Uses the ``search_docs`` query type which returns documents with
-        properly highlighted match spans.
+        full_text = "".join(s["text"] for s in doc_spans)
+        return {
+            "doc_ix": doc.get("doc_ix", 0),
+            "doc_len": doc.get("doc_len", 0),
+            "disp_len": doc.get("disp_len", 0),
+            "spans": doc_spans,
+            "full_text": full_text,
+        }
+
+    async def search(self, query: str, max_docs: int = 10) -> dict:
+        """Search for *query* and return up to *max_docs* unique documents.
+
+        The infini-gram ``search_docs`` API returns at most 10 results per
+        call.  When more are requested, this method makes repeated calls
+        and deduplicates by ``doc_ix``.
 
         Returns a dict with keys: documents, query, count.
         """
-        result = await self._post(
-            {
-                "index": self._index,
-                "query_type": "search_docs",
-                "query": query,
-                "maxnum": max_docs,
-            }
-        )
+        seen_doc_ixs: set[int] = set()
+        collected: list[dict] = []
+        count: int | None = None
 
-        count = result.get("cnt", 0)
-        if count == 0:
-            return {"documents": [], "query": query, "count": 0}
+        page_size = min(max_docs, API_PAGE_SIZE)
 
-        documents = []
-        for doc in result.get("documents", []):
-            # Spans from search_docs are 2-element arrays: [text, highlight]
-            # highlight is None for non-match, an integer (e.g. 0) for match
-            raw_spans = doc.get("spans", [])
-            doc_spans = []
-            for span in raw_spans:
-                if isinstance(span, list) and len(span) >= 2:
-                    doc_spans.append(
-                        {
-                            "text": span[0],
-                            "is_match": span[1] is not None,
-                        }
-                    )
+        for _ in range(MAX_ATTEMPTS):
+            if len(collected) >= max_docs:
+                break
 
-            full_text = "".join(s["text"] for s in doc_spans)
-            documents.append(
+            result = await self._post(
                 {
-                    "doc_ix": doc.get("doc_ix", 0),
-                    "doc_len": doc.get("doc_len", 0),
-                    "disp_len": doc.get("disp_len", 0),
-                    "spans": doc_spans,
-                    "full_text": full_text,
+                    "index": self._index,
+                    "query_type": "search_docs",
+                    "query": query,
+                    "maxnum": page_size,
                 }
             )
 
-        return {"documents": documents, "query": query, "count": count}
+            batch_count = result.get("cnt", 0)
+            if count is None:
+                count = batch_count
+            if batch_count == 0:
+                break
+
+            batch_docs = result.get("documents", [])
+            if not batch_docs:
+                break
+
+            new_in_batch = 0
+            for doc in batch_docs:
+                doc_ix = doc.get("doc_ix", 0)
+                if doc_ix in seen_doc_ixs:
+                    continue
+                seen_doc_ixs.add(doc_ix)
+                new_in_batch += 1
+                collected.append(self._parse_document(doc))
+
+                if len(collected) >= max_docs:
+                    break
+
+            # No new unique docs — result space likely exhausted
+            if new_in_batch == 0:
+                break
+
+        return {"documents": collected, "query": query, "count": count or 0}

--- a/influence-workbench/backend/config.py
+++ b/influence-workbench/backend/config.py
@@ -22,6 +22,7 @@ class WorkbenchConfig(BaseModel):
     infinigram_api_url: str = "https://api.infini-gram.io/"
     infinigram_index: str = "v4_olmo-mix-1124_llama"
     infinigram_max_docs: int = 10
+    infinigram_max_attempts: int = 10
     claude_model: str = "claude-haiku-4-5-20251001"
 
 

--- a/influence-workbench/backend/models.py
+++ b/influence-workbench/backend/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +100,7 @@ class RunResults(BaseModel):
 
 class SearchPretrainingRequest(BaseModel):
     completion: str
-    max_docs: int = 10
+    max_docs: int = Field(default=10, ge=1, le=50)
 
 
 class InfinigramDocSpan(BaseModel):

--- a/influence-workbench/backend/models.py
+++ b/influence-workbench/backend/models.py
@@ -100,7 +100,7 @@ class RunResults(BaseModel):
 
 class SearchPretrainingRequest(BaseModel):
     completion: str
-    max_docs: int = Field(default=10, ge=1, le=50)
+    max_docs: int = Field(default=10, ge=1, le=100)
 
 
 class InfinigramDocSpan(BaseModel):

--- a/influence-workbench/backend/span.py
+++ b/influence-workbench/backend/span.py
@@ -46,6 +46,9 @@ def extract_span(
     ``document_text[match_start:match_end]``.
     """
     completion = document_text[match_start:match_end]
+    # Ensure leading space for correct SentencePiece tokenization.
+    if completion and not completion.startswith(" "):
+        completion = " " + completion
 
     raw_start = max(0, match_start - span_length)
     # Snap to a sentence boundary (move forward to avoid partial sentences)

--- a/influence-workbench/backend/tests/test_infinigram_client.py
+++ b/influence-workbench/backend/tests/test_infinigram_client.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.clients.infinigram import InfinigramClient, API_PAGE_SIZE, MAX_ATTEMPTS
+from backend.clients.infinigram import InfinigramClient, API_PAGE_SIZE, DEFAULT_MAX_ATTEMPTS
 
 
 def _make_response(doc_ixs: list[int], count: int = 1000) -> dict:
@@ -71,7 +71,7 @@ async def test_search_early_exit_all_dupes():
 
 @pytest.mark.asyncio
 async def test_search_max_attempts_cap():
-    """Does not exceed MAX_ATTEMPTS API calls."""
+    """Does not exceed DEFAULT_MAX_ATTEMPTS API calls."""
     client = _make_client()
 
     call_count = 0
@@ -85,8 +85,8 @@ async def test_search_max_attempts_cap():
     client._post = always_new_docs  # type: ignore[assignment]
 
     result = await client.search("test", max_docs=200)
-    assert call_count <= MAX_ATTEMPTS
-    assert len(result["documents"]) <= MAX_ATTEMPTS * API_PAGE_SIZE
+    assert call_count <= DEFAULT_MAX_ATTEMPTS
+    assert len(result["documents"]) <= DEFAULT_MAX_ATTEMPTS * API_PAGE_SIZE
 
 
 @pytest.mark.asyncio

--- a/influence-workbench/backend/tests/test_infinigram_client.py
+++ b/influence-workbench/backend/tests/test_infinigram_client.py
@@ -1,0 +1,127 @@
+"""Unit tests for InfinigramClient deduplication logic."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.clients.infinigram import InfinigramClient, API_PAGE_SIZE, MAX_ATTEMPTS
+
+
+def _make_response(doc_ixs: list[int], count: int = 1000) -> dict:
+    """Build a fake search_docs API response."""
+    return {
+        "cnt": count,
+        "documents": [
+            {
+                "doc_ix": ix,
+                "doc_len": 500,
+                "disp_len": 200,
+                "spans": [["some text ", None], ["match", 0]],
+            }
+            for ix in doc_ixs
+        ],
+    }
+
+
+def _make_client() -> InfinigramClient:
+    client = InfinigramClient(
+        http_client=None,  # type: ignore[arg-type]
+        api_url="https://api.test/",
+        index="test-index",
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_search_dedup_multiple_calls():
+    """Overlapping batches yield the correct number of unique documents."""
+    client = _make_client()
+
+    # Call 1: docs 0-9, Call 2: docs 5-14 (5 overlap), Call 3: docs 10-19
+    client._post = AsyncMock(
+        side_effect=[
+            _make_response(list(range(10))),
+            _make_response(list(range(5, 15))),
+            _make_response(list(range(10, 20))),
+        ]
+    )
+
+    result = await client.search("test", max_docs=15)
+    assert len(result["documents"]) == 15
+    doc_ixs = [d["doc_ix"] for d in result["documents"]]
+    assert len(set(doc_ixs)) == 15  # all unique
+    assert result["count"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_search_early_exit_all_dupes():
+    """Exits early when a batch adds zero new documents."""
+    client = _make_client()
+
+    same_docs = _make_response([1, 2, 3], count=3)
+    client._post = AsyncMock(return_value=same_docs)
+
+    result = await client.search("rare query", max_docs=20)
+    assert len(result["documents"]) == 3
+    # First call gets 3 new, second call gets 0 new → exits
+    assert client._post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_search_max_attempts_cap():
+    """Does not exceed MAX_ATTEMPTS API calls."""
+    client = _make_client()
+
+    call_count = 0
+
+    async def always_new_docs(payload: dict) -> dict:
+        nonlocal call_count
+        start = call_count * 10
+        call_count += 1
+        return _make_response(list(range(start, start + 10)), count=10000)
+
+    client._post = always_new_docs  # type: ignore[assignment]
+
+    result = await client.search("test", max_docs=200)
+    assert call_count <= MAX_ATTEMPTS
+    assert len(result["documents"]) <= MAX_ATTEMPTS * API_PAGE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_search_small_request_single_call():
+    """Requesting <= 10 docs makes exactly one API call."""
+    client = _make_client()
+    client._post = AsyncMock(return_value=_make_response(list(range(5)), count=100))
+
+    result = await client.search("test", max_docs=5)
+    assert len(result["documents"]) == 5
+    assert client._post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_search_zero_count():
+    """Zero-count response returns empty results with a single call."""
+    client = _make_client()
+    client._post = AsyncMock(return_value={"cnt": 0, "documents": []})
+
+    result = await client.search("nonexistent", max_docs=10)
+    assert result["documents"] == []
+    assert result["count"] == 0
+    assert client._post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_search_parses_spans():
+    """Documents have correctly parsed spans and full_text."""
+    client = _make_client()
+    client._post = AsyncMock(return_value=_make_response([42]))
+
+    result = await client.search("test", max_docs=1)
+    doc = result["documents"][0]
+    assert doc["doc_ix"] == 42
+    assert len(doc["spans"]) == 2
+    assert doc["spans"][0] == {"text": "some text ", "is_match": False}
+    assert doc["spans"][1] == {"text": "match", "is_match": True}
+    assert doc["full_text"] == "some text match"

--- a/influence-workbench/backend/tests/test_span.py
+++ b/influence-workbench/backend/tests/test_span.py
@@ -8,14 +8,14 @@ from backend.span import extract_span
 def test_basic_extraction():
     text = "The quick brown fox jumps over the lazy dog."
     prompt, completion = extract_span(text, 16, 25, span_length=16)
-    assert completion == "fox jumps"
+    assert completion == " fox jumps"
     assert prompt == text[:16]
 
 
 def test_match_at_start():
     text = "Hello world. This is a test."
     prompt, completion = extract_span(text, 0, 5, span_length=100)
-    assert completion == "Hello"
+    assert completion == " Hello"
     assert prompt == ""
 
 
@@ -24,14 +24,14 @@ def test_match_at_end():
     match_start = len(text) - 11  # "Final word."
     match_end = len(text)
     prompt, completion = extract_span(text, match_start, match_end, span_length=100)
-    assert completion == "Final word."
+    assert completion == " Final word."
     assert len(prompt) > 0
 
 
 def test_span_larger_than_document():
     text = "Short text."
     prompt, completion = extract_span(text, 6, 11, span_length=1000)
-    assert completion == "text."
+    assert completion == " text."
     assert prompt == "Short "
 
 
@@ -42,7 +42,7 @@ def test_sentence_snapping():
     match_end = len(text)
     # Use a span_length that puts raw_start mid-sentence
     prompt, completion = extract_span(text, match_start, match_end, span_length=30)
-    assert completion == "The match here."
+    assert completion == " The match here."
     # Prompt should snap to a sentence boundary
     assert not prompt or prompt[0].isupper() or prompt.startswith(" ")
 
@@ -50,12 +50,28 @@ def test_sentence_snapping():
 def test_zero_span_length():
     text = "Hello world."
     prompt, completion = extract_span(text, 6, 12, span_length=0)
-    assert completion == "world."
+    assert completion == " world."
     assert prompt == ""
 
 
 def test_exact_match_boundaries():
     text = "ABCDEFGHIJ"
     prompt, completion = extract_span(text, 5, 10, span_length=5)
-    assert completion == "FGHIJ"
+    assert completion == " FGHIJ"
     assert prompt == "ABCDE"
+
+
+def test_completion_leading_space_added():
+    """Completion gets a leading space for correct tokenization."""
+    text = "Hello world."
+    prompt, completion = extract_span(text, 6, 12, span_length=6)
+    assert completion.startswith(" ")
+
+
+def test_completion_preserves_existing_leading_space():
+    """If the match text already starts with a space, don't double it."""
+    text = "Hello world."
+    # Match starts at the space before 'world'
+    prompt, completion = extract_span(text, 5, 12, span_length=5)
+    assert completion == " world."
+    assert not completion.startswith("  ")

--- a/influence-workbench/backend/tests/test_tools.py
+++ b/influence-workbench/backend/tests/test_tools.py
@@ -46,7 +46,7 @@ async def test_extract_span(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["completion"] == "The target completion here."
+    assert data["completion"] == " The target completion here."
     assert len(data["prompt"]) > 0
 
 

--- a/influence-workbench/config.yaml
+++ b/influence-workbench/config.yaml
@@ -10,4 +10,5 @@ data_dir: "data"
 infinigram_api_url: "https://api.infini-gram.io/"
 infinigram_index: "v4_olmo-mix-1124_llama"
 infinigram_max_docs: 10
+infinigram_max_attempts: 10
 claude_model: "claude-haiku-4-5-20251001"

--- a/influence-workbench/frontend/src/lib/components/SearchPretrainingModal.svelte
+++ b/influence-workbench/frontend/src/lib/components/SearchPretrainingModal.svelte
@@ -146,7 +146,7 @@
 				<input
 					type="number"
 					min="1"
-					max="10"
+					max="50"
 					bind:value={maxResults}
 					class="max-results"
 				/>

--- a/influence-workbench/frontend/src/lib/components/SearchPretrainingModal.svelte
+++ b/influence-workbench/frontend/src/lib/components/SearchPretrainingModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Modal from './Modal.svelte';
 	import * as api from '$lib/api';
-	import type { InfinigramDocument, ExtractSpanResponse } from '$lib/types';
+	import type { InfinigramDocument } from '$lib/types';
 
 	let {
 		open = false,
@@ -23,13 +23,10 @@
 	// Multi-select for batch add
 	let checkedDocs = $state<Set<number>>(new Set());
 	let spanLength = $state(256);
-	let adding = $state(false);
-
 	// Single-doc preview
 	let previewDoc = $state<InfinigramDocument | null>(null);
 	let extractedPrompt = $state('');
 	let extractedCompletion = $state('');
-	let extracting = $state(false);
 
 	async function doSearch() {
 		if (!searchQuery.trim()) return;
@@ -59,6 +56,14 @@
 		checkedDocs = next;
 	}
 
+	function toggleSelectAll() {
+		if (checkedDocs.size === documents.length) {
+			checkedDocs = new Set();
+		} else {
+			checkedDocs = new Set(documents.map((_, i) => i));
+		}
+	}
+
 	function getMatchOffsets(doc: InfinigramDocument): { start: number; end: number } {
 		let offset = 0;
 		for (const span of doc.spans) {
@@ -70,52 +75,63 @@
 		return { start: 0, end: 0 };
 	}
 
-	async function addCheckedPairs() {
-		if (checkedDocs.size === 0) return;
-		adding = true;
-		searchError = '';
-		try {
-			const extractions = await Promise.all(
-				[...checkedDocs].map(async (idx) => {
-					const doc = documents[idx];
-					const { start, end } = getMatchOffsets(doc);
-					if (start === end) return null;
-					return api.extractSpan(doc.full_text, start, end, spanLength);
-				})
-			);
-			const pairs = extractions
-				.filter((e): e is ExtractSpanResponse => e !== null)
-				.map((e) => ({ prompt: e.prompt, completion: e.completion }));
-			if (pairs.length > 0) {
-				onuse(pairs);
-				onclose();
+	/** Client-side span extraction — mirrors backend/span.py logic. */
+	function extractSpanLocal(
+		text: string,
+		matchStart: number,
+		matchEnd: number,
+		length: number
+	): { prompt: string; completion: string } | null {
+		if (matchStart === matchEnd) return null;
+		let completion = text.slice(matchStart, matchEnd);
+		if (completion && !completion.startsWith(' ')) {
+			completion = ' ' + completion;
+		}
+		let rawStart = Math.max(0, matchStart - length);
+		// Snap to sentence boundary (look for '. ', '! ', '? ')
+		if (rawStart > 0) {
+			const slice = text.slice(rawStart);
+			const m = slice.match(/(?<=[.!?])\s+/);
+			if (m && m.index !== undefined && m.index < 60) {
+				const snapped = rawStart + m.index + m[0].length;
+				if (snapped < matchStart) {
+					rawStart = snapped;
+				}
 			}
-		} catch (e) {
-			searchError = String(e);
-		} finally {
-			adding = false;
+		}
+		const prompt = text.slice(rawStart, matchStart);
+		return { prompt, completion };
+	}
+
+	function addCheckedPairs() {
+		if (checkedDocs.size === 0) return;
+		const pairs: Array<{ prompt: string; completion: string }> = [];
+		for (const idx of checkedDocs) {
+			const doc = documents[idx];
+			const { start, end } = getMatchOffsets(doc);
+			const result = extractSpanLocal(doc.full_text, start, end, spanLength);
+			if (result) pairs.push(result);
+		}
+		if (pairs.length > 0) {
+			onuse(pairs);
+			onclose();
 		}
 	}
 
 	// Single-doc preview
-	async function previewDocument(doc: InfinigramDocument) {
+	function previewDocument(doc: InfinigramDocument) {
 		previewDoc = doc;
-		await extractPreview();
+		extractPreview();
 	}
 
-	async function extractPreview() {
+	function extractPreview() {
 		if (!previewDoc) return;
 		const { start, end } = getMatchOffsets(previewDoc);
 		if (start === end) return;
-		extracting = true;
-		try {
-			const result = await api.extractSpan(previewDoc.full_text, start, end, spanLength);
+		const result = extractSpanLocal(previewDoc.full_text, start, end, spanLength);
+		if (result) {
 			extractedPrompt = result.prompt;
 			extractedCompletion = result.completion;
-		} catch (e) {
-			searchError = String(e);
-		} finally {
-			extracting = false;
 		}
 	}
 
@@ -146,7 +162,7 @@
 				<input
 					type="number"
 					min="1"
-					max="50"
+					max="100"
 					bind:value={maxResults}
 					class="max-results"
 				/>
@@ -165,8 +181,8 @@
 		{/if}
 
 		{#if documents.length > 0 && !previewDoc}
-			<div class="span-control">
-				<label>
+			<div class="list-toolbar">
+				<label class="span-control">
 					Prompt length: {spanLength} chars
 					<input
 						type="range"
@@ -177,6 +193,9 @@
 						oninput={onSpanChange}
 					/>
 				</label>
+				<button class="select-all" onclick={toggleSelectAll}>
+					{checkedDocs.size === documents.length ? 'Deselect all' : 'Select all'}
+				</button>
 			</div>
 
 			<div class="doc-list">
@@ -202,8 +221,8 @@
 			</div>
 
 			{#if checkedDocs.size > 0}
-				<button class="primary" onclick={addCheckedPairs} disabled={adding}>
-					{adding ? 'Extracting...' : `Add ${checkedDocs.size} pair${checkedDocs.size > 1 ? 's' : ''}`}
+				<button class="primary" onclick={addCheckedPairs}>
+					{`Add ${checkedDocs.size} pair${checkedDocs.size > 1 ? 's' : ''}`}
 				</button>
 			{/if}
 		{/if}
@@ -234,9 +253,7 @@
 					</label>
 				</div>
 
-				{#if extracting}
-					<div class="loading">Extracting span...</div>
-				{:else if extractedPrompt || extractedCompletion}
+				{#if extractedPrompt || extractedCompletion}
 					<div class="extracted">
 						<div class="field-group">
 							<label>Prompt</label>
@@ -353,11 +370,17 @@
 		border: 1px solid var(--border, #ddd);
 		border-radius: 4px;
 	}
-	.span-control {
+	.list-toolbar {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
 	}
-	.span-control label {
+	.select-all {
+		font-size: 0.8rem;
+		white-space: nowrap;
+	}
+	.span-control {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
@@ -366,10 +389,7 @@
 	.span-control input[type='range'] {
 		width: 200px;
 	}
-	.loading {
-		font-size: 0.85rem;
-		color: var(--text-muted, #888);
-	}
+
 	.extracted {
 		display: flex;
 		flex-direction: column;

--- a/influence-workbench/frontend/src/routes/create/+page.svelte
+++ b/influence-workbench/frontend/src/routes/create/+page.svelte
@@ -147,6 +147,11 @@
 		}
 	}
 
+	/** Ensure completion starts with a space for correct tokenization. */
+	function ensureLeadingSpace(text: string): string {
+		return text && !text.startsWith(' ') ? ' ' + text : text;
+	}
+
 	// Tool callbacks — append new pairs
 	function onSearchUse(newPairs: Array<{ prompt: string; completion: string }>) {
 		pairs = [
@@ -154,7 +159,7 @@
 			...newPairs.map((p, i) => ({
 				pair_id: `p${Date.now()}_${i}`,
 				prompt: p.prompt,
-				completion: p.completion,
+				completion: ensureLeadingSpace(p.completion),
 				role: 'both' as PairRole,
 				metadata: {}
 			}))
@@ -167,7 +172,7 @@
 			{
 				pair_id: `p${Date.now()}`,
 				prompt,
-				completion,
+				completion: ensureLeadingSpace(completion),
 				role: 'both' as PairRole,
 				metadata: {}
 			}
@@ -281,6 +286,9 @@
 						placeholder="Completion"
 						rows="2"
 					></textarea>
+					{#if pair.completion && !pair.completion.startsWith(' ')}
+						<div class="completion-warning">Completion has no leading space — tokenization may be incorrect</div>
+					{/if}
 				</div>
 			{/each}
 		</div>
@@ -399,6 +407,13 @@
 	}
 	.pair-id { max-width: 160px; }
 	textarea { resize: vertical; min-height: 48px; }
+	.completion-warning {
+		font-size: 0.75rem;
+		color: #e65100;
+		background: #fff3e0;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+	}
 	.actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
 	.error {
 		background: rgba(239, 83, 80, 0.1);


### PR DESCRIPTION
## Summary

- **Dedup loop**: The infini-gram search_docs API silently caps results at 10 per call. The client now loops with maxnum=10, deduplicating by doc_ix, until the requested count is reached or max attempts is hit
- **Configurable max attempts**: infinigram_max_attempts in config.yaml (default 10), passed through to InfinigramClient
- **Max docs raised to 100**: Backend validates Field(ge=1, le=100), frontend input allows up to 100
- **Visible leading space on completions**: Completions get a leading space for correct SentencePiece tokenization, applied visibly at creation time (span extraction, Claude generation). Warning banner shown on pairs missing it
- **Client-side span extraction**: Batch "Add N pairs" and single-doc preview no longer make API calls — extraction is done in JavaScript, making it instant
- **Select all button**: Toggle to select/deselect all documents in search results

Closes #8

## Test plan

- [x] 76 backend tests pass (6 new dedup tests, updated span/tools tests)
- [x] 0 TypeScript errors
- [x] Manual: curl with max_docs=30 returns 30 unique documents
- [ ] Manual: select all then Add N pairs is instant even with many docs
- [ ] Manual: completions from search/generate have visible leading space
- [ ] Manual: manually typed completion without space shows warning

Generated with [Claude Code](https://claude.com/claude-code)