### PR TITLE
axis-viewer: Activation extraction API (#13)

### DIFF
--- a/axis-viewer/backend/app.py
+++ b/axis-viewer/backend/app.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from huggingface_hub import hf_hub_download
 
 from backend.config import AxisViewerConfig, load_config
+from backend.routes.project import router as project_router
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,8 @@ def create_app(config_path: str = "config.yaml") -> FastAPI:
             "target_layer": config.target_layer,
             "total_layers": config.total_layers,
         }
+
+    app.include_router(project_router)
 
     return app
 

--- a/axis-viewer/backend/models.py
+++ b/axis-viewer/backend/models.py
@@ -1,3 +1,36 @@
 """Pydantic request/response schemas for the axis-viewer API."""
 
 from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class TokenProjection(BaseModel):
+    token_id: int
+    token_str: str
+    projection: float  # dot(activation, axis) / norm(axis) at target layer
+    position: int  # index in token sequence
+
+
+class TurnSpan(BaseModel):
+    turn: int
+    role: str  # "user" | "assistant" | "system"
+    start: int  # token index (inclusive)
+    end: int  # token index (exclusive)
+    text: str
+    mean_projection: float  # mean projection across tokens in this span
+
+
+class ProjectionResponse(BaseModel):
+    tokens: list[TokenProjection]
+    spans: list[TurnSpan]  # empty list for raw text mode
+    layer: int
+    model_name: str
+
+
+class ChatRequest(BaseModel):
+    conversation: list[dict]  # [{"role": "user", "content": "..."}, ...]
+
+
+class RawTextRequest(BaseModel):
+    text: str

--- a/axis-viewer/backend/routes/project.py
+++ b/axis-viewer/backend/routes/project.py
@@ -1,0 +1,270 @@
+"""Projection endpoints: project token activations onto the Assistant Axis."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+
+import torch
+from fastapi import APIRouter, HTTPException, Request
+
+from backend.models import (
+    ChatRequest,
+    ProjectionResponse,
+    RawTextRequest,
+    TokenProjection,
+    TurnSpan,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/project", tags=["project"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _project_tokens(
+    activations: torch.Tensor,
+    axis: torch.Tensor,
+    layer: int,
+) -> list[float]:
+    """Project each token's activation onto the axis at *layer*.
+
+    Parameters
+    ----------
+    activations:
+        Tensor of shape ``(num_tokens, hidden_size)`` – activations at the
+        target layer for every token.
+    axis:
+        Tensor of shape ``(num_layers, hidden_size)``.
+    layer:
+        Which layer index to use from *axis*.
+
+    Returns
+    -------
+    List of scalar projection values, one per token.
+    """
+    axis_vec = axis[layer].float()
+    axis_norm = torch.norm(axis_vec)
+    if axis_norm == 0:
+        return [0.0] * activations.shape[0]
+    axis_vec = axis_vec / axis_norm
+    acts = activations.float()
+    projections = (acts @ axis_vec).tolist()
+    return projections
+
+
+def _build_token_projections(
+    token_ids: list[int],
+    projections: list[float],
+    tokenizer,
+) -> list[TokenProjection]:
+    """Build a list of ``TokenProjection`` from ids, projections, and a tokenizer."""
+    tokens: list[TokenProjection] = []
+    for i, (tid, proj) in enumerate(zip(token_ids, projections)):
+        token_str = tokenizer.decode([tid])
+        tokens.append(
+            TokenProjection(
+                token_id=tid,
+                token_str=token_str,
+                projection=proj,
+                position=i,
+            )
+        )
+    return tokens
+
+
+def _build_turn_spans(
+    spans: list[dict],
+    projections: list[float],
+) -> list[TurnSpan]:
+    """Compute per-span mean projections and return ``TurnSpan`` objects."""
+    result: list[TurnSpan] = []
+    for span in spans:
+        start = span["start"]
+        end = span["end"]
+        span_projs = projections[start:end]
+        mean_proj = sum(span_projs) / len(span_projs) if span_projs else 0.0
+        result.append(
+            TurnSpan(
+                turn=span["turn"],
+                role=span["role"],
+                start=start,
+                end=end,
+                text=span["text"],
+                mean_projection=mean_proj,
+            )
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+def _mock_tokens_from_words(words: list[str], offset: int = 0) -> list[TokenProjection]:
+    """Build mock ``TokenProjection`` objects by treating each word as a token."""
+    return [
+        TokenProjection(
+            token_id=offset + i,
+            token_str=word,
+            projection=random.uniform(-2.0, 2.0),
+            position=offset + i,
+        )
+        for i, word in enumerate(words)
+    ]
+
+
+def _mock_chat_response(conversation: list[dict]) -> ProjectionResponse:
+    """Return synthetic data when the model is not loaded."""
+    tokens: list[TokenProjection] = []
+    spans: list[TurnSpan] = []
+    pos = 0
+    for turn_idx, msg in enumerate(conversation):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        words = content.split() or ["<empty>"]
+        span_tokens = _mock_tokens_from_words(words, offset=pos)
+        span_projs = [t.projection for t in span_tokens]
+        mean_proj = sum(span_projs) / len(span_projs) if span_projs else 0.0
+        spans.append(
+            TurnSpan(
+                turn=turn_idx,
+                role=role,
+                start=pos,
+                end=pos + len(span_tokens),
+                text=content,
+                mean_projection=mean_proj,
+            )
+        )
+        tokens.extend(span_tokens)
+        pos += len(span_tokens)
+    return ProjectionResponse(
+        tokens=tokens,
+        spans=spans,
+        layer=32,
+        model_name="mock",
+    )
+
+
+def _mock_raw_response(text: str) -> ProjectionResponse:
+    """Return synthetic data for raw text when the model is not loaded."""
+    words = text.split() or ["<empty>"]
+    return ProjectionResponse(
+        tokens=_mock_tokens_from_words(words),
+        spans=[],
+        layer=32,
+        model_name="mock",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Blocking extraction functions (run via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+def _extract_chat(request: Request, conversation: list[dict]) -> ProjectionResponse:
+    """Extract activations for a chat conversation and project onto axis.
+
+    This function performs GPU work and should be called via
+    ``asyncio.to_thread``.
+    """
+    config = request.app.state.config
+    extractor = request.app.state.extractor
+    encoder = request.app.state.encoder
+    axis = request.app.state.axis
+    target_layer = config.target_layer
+
+    # Get token ids and turn span boundaries
+    token_ids, spans = encoder.build_turn_spans(
+        conversation, enable_thinking=False,
+    )
+
+    # Extract activations at the target layer
+    activations = extractor.full_conversation(
+        conversation,
+        layer=target_layer,
+        chat_format=True,
+        enable_thinking=False,
+    )
+    # activations shape: (num_tokens, hidden_size)
+
+    projections = _project_tokens(activations, axis, target_layer)
+
+    tokenizer = encoder.tokenizer
+    token_projs = _build_token_projections(token_ids, projections, tokenizer)
+    turn_spans = _build_turn_spans(spans, projections)
+
+    return ProjectionResponse(
+        tokens=token_projs,
+        spans=turn_spans,
+        layer=target_layer,
+        model_name=config.model_name,
+    )
+
+
+def _extract_raw(request: Request, text: str) -> ProjectionResponse:
+    """Extract activations for raw text (no chat template) and project onto axis.
+
+    This function performs GPU work and should be called via
+    ``asyncio.to_thread``.
+    """
+    config = request.app.state.config
+    extractor = request.app.state.extractor
+    axis = request.app.state.axis
+    target_layer = config.target_layer
+
+    # full_conversation accepts a plain string with chat_format=False
+    activations = extractor.full_conversation(
+        text,
+        layer=target_layer,
+        chat_format=False,
+    )
+    # activations shape: (num_tokens, hidden_size)
+
+    tokenizer = request.app.state.probing_model.tokenizer
+    token_ids = tokenizer.encode(text, add_special_tokens=False)
+
+    projections = _project_tokens(activations, axis, target_layer)
+    token_projs = _build_token_projections(token_ids, projections, tokenizer)
+
+    return ProjectionResponse(
+        tokens=token_projs,
+        spans=[],
+        layer=target_layer,
+        model_name=config.model_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/chat", response_model=ProjectionResponse)
+async def project_chat(body: ChatRequest, request: Request):
+    """Project a multi-turn conversation onto the Assistant Axis."""
+    config = request.app.state.config
+
+    if config.mock_model:
+        return _mock_chat_response(body.conversation)
+
+    if request.app.state.extractor is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    return await asyncio.to_thread(_extract_chat, request, body.conversation)
+
+
+@router.post("/raw", response_model=ProjectionResponse)
+async def project_raw(body: RawTextRequest, request: Request):
+    """Project raw text (no chat template) onto the Assistant Axis."""
+    config = request.app.state.config
+
+    if config.mock_model:
+        return _mock_raw_response(body.text)
+
+    if request.app.state.extractor is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    return await asyncio.to_thread(_extract_raw, request, body.text)

--- a/axis-viewer/backend/tests/test_project.py
+++ b/axis-viewer/backend/tests/test_project.py
@@ -1,0 +1,174 @@
+"""Tests for the /api/project endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+@pytest.fixture()
+def mock_client(tmp_path):
+    """Create a test client with mock mode enabled."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("mock_model: true\n")
+    app = create_app(config_path=str(config_path))
+    with TestClient(app) as client:
+        yield client
+
+
+class TestSchemas:
+    """Verify Pydantic schemas import and validate correctly."""
+
+    def test_token_projection(self):
+        from backend.models import TokenProjection
+
+        tp = TokenProjection(token_id=42, token_str="hello", projection=1.5, position=0)
+        assert tp.token_id == 42
+        assert tp.projection == 1.5
+
+    def test_turn_span(self):
+        from backend.models import TurnSpan
+
+        span = TurnSpan(
+            turn=0, role="user", start=0, end=5, text="hi", mean_projection=0.3,
+        )
+        assert span.role == "user"
+        assert span.end == 5
+
+    def test_projection_response(self):
+        from backend.models import ProjectionResponse, TokenProjection
+
+        resp = ProjectionResponse(
+            tokens=[
+                TokenProjection(
+                    token_id=1, token_str="a", projection=0.5, position=0,
+                )
+            ],
+            spans=[],
+            layer=32,
+            model_name="test",
+        )
+        assert resp.layer == 32
+        assert len(resp.tokens) == 1
+
+    def test_chat_request(self):
+        from backend.models import ChatRequest
+
+        req = ChatRequest(conversation=[{"role": "user", "content": "hello"}])
+        assert len(req.conversation) == 1
+
+    def test_raw_text_request(self):
+        from backend.models import RawTextRequest
+
+        req = RawTextRequest(text="some raw text")
+        assert req.text == "some raw text"
+
+
+class TestMockChatEndpoint:
+    """Test POST /api/project/chat in mock mode."""
+
+    def test_basic_response_shape(self, mock_client):
+        resp = mock_client.post(
+            "/api/project/chat",
+            json={
+                "conversation": [
+                    {"role": "user", "content": "Hello there"},
+                    {"role": "assistant", "content": "Hi how are you"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "tokens" in data
+        assert "spans" in data
+        assert data["layer"] == 32
+        assert data["model_name"] == "mock"
+
+    def test_spans_match_conversation(self, mock_client):
+        conversation = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "World"},
+        ]
+        resp = mock_client.post(
+            "/api/project/chat", json={"conversation": conversation},
+        )
+        data = resp.json()
+        assert len(data["spans"]) == 2
+        assert data["spans"][0]["role"] == "user"
+        assert data["spans"][1]["role"] == "assistant"
+
+    def test_span_boundaries_are_contiguous(self, mock_client):
+        conversation = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello world"},
+            {"role": "assistant", "content": "Hi there friend"},
+        ]
+        resp = mock_client.post(
+            "/api/project/chat", json={"conversation": conversation},
+        )
+        data = resp.json()
+        spans = data["spans"]
+        # Each span's start should equal the previous span's end
+        for i in range(1, len(spans)):
+            assert spans[i]["start"] == spans[i - 1]["end"]
+
+    def test_token_count_matches_spans(self, mock_client):
+        conversation = [
+            {"role": "user", "content": "one two three"},
+        ]
+        resp = mock_client.post(
+            "/api/project/chat", json={"conversation": conversation},
+        )
+        data = resp.json()
+        total_span_tokens = sum(s["end"] - s["start"] for s in data["spans"])
+        assert total_span_tokens == len(data["tokens"])
+
+    def test_empty_conversation(self, mock_client):
+        resp = mock_client.post(
+            "/api/project/chat", json={"conversation": []},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["tokens"] == []
+        assert data["spans"] == []
+
+
+class TestMockRawEndpoint:
+    """Test POST /api/project/raw in mock mode."""
+
+    def test_basic_response_shape(self, mock_client):
+        resp = mock_client.post(
+            "/api/project/raw", json={"text": "Hello world foo bar"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "tokens" in data
+        assert data["spans"] == []
+        assert data["layer"] == 32
+        assert data["model_name"] == "mock"
+
+    def test_token_count(self, mock_client):
+        text = "one two three four"
+        resp = mock_client.post("/api/project/raw", json={"text": text})
+        data = resp.json()
+        # Mock splits on whitespace
+        assert len(data["tokens"]) == 4
+
+    def test_positions_are_sequential(self, mock_client):
+        resp = mock_client.post(
+            "/api/project/raw", json={"text": "a b c d e"},
+        )
+        data = resp.json()
+        positions = [t["position"] for t in data["tokens"]]
+        assert positions == list(range(len(positions)))
+
+
+class TestHealthEndpoint:
+    """Verify health check still works with the router included."""
+
+    def test_health_mock(self, mock_client):
+        resp = mock_client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "mock"


### PR DESCRIPTION
## Summary
- `POST /api/project/chat` — project multi-turn conversation tokens onto the Assistant Axis
- `POST /api/project/raw` — project raw text tokens (no chat template) onto the axis
- Pydantic schemas: `TokenProjection`, `TurnSpan`, `ProjectionResponse`, `ChatRequest`, `RawTextRequest`
- Mock mode returns synthetic data for testing without GPU
- GPU extraction runs in thread pool via `asyncio.to_thread`

## Test plan
- [x] 14 pytest tests passing (schemas, mock chat, mock raw, health)
- [ ] Verify with real model that projections match assistant-axis notebook outputs

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)