### PR TITLE
axis-viewer: Token heatmap & trajectory chart components (#14)

### DIFF
--- a/axis-viewer/frontend/src/lib/api.ts
+++ b/axis-viewer/frontend/src/lib/api.ts
@@ -2,6 +2,8 @@
  * API client for the axis-viewer backend.
  */
 
+import type { ProjectionResponse } from './types';
+
 const BASE = '/api';
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -18,4 +20,20 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 export async function getHealth() {
 	return request<{ status: string; model: string }>('/health');
+}
+
+export async function projectChat(
+	conversation: Array<{ role: string; content: string }>
+): Promise<ProjectionResponse> {
+	return request<ProjectionResponse>('/project/chat', {
+		method: 'POST',
+		body: JSON.stringify({ conversation })
+	});
+}
+
+export async function projectRaw(text: string): Promise<ProjectionResponse> {
+	return request<ProjectionResponse>('/project/raw', {
+		method: 'POST',
+		body: JSON.stringify({ text })
+	});
 }

--- a/axis-viewer/frontend/src/lib/components/TokenHeatmap.svelte
+++ b/axis-viewer/frontend/src/lib/components/TokenHeatmap.svelte
@@ -1,0 +1,356 @@
+<script lang="ts">
+	import type { ProjectionResponse, TokenProjection, TurnSpan } from '$lib/types';
+	import Tooltip from './Tooltip.svelte';
+
+	let { response }: { response: ProjectionResponse } = $props();
+
+	// Tooltip state
+	let tooltipX = $state(0);
+	let tooltipY = $state(0);
+	let hoveredToken = $state<TokenProjection | null>(null);
+	let hoveredTurn = $state<TurnSpan | null>(null);
+
+	// Projection extent for color normalization
+	let extent = $derived.by(() => {
+		if (response.tokens.length === 0) return { min: 0, max: 1 };
+		const projections = response.tokens.map((t) => t.projection);
+		return {
+			min: Math.min(...projections),
+			max: Math.max(...projections)
+		};
+	});
+
+	// Build a lookup from position to the span it belongs to
+	let spanByPosition = $derived.by(() => {
+		const map = new Map<number, TurnSpan>();
+		for (const span of response.spans) {
+			for (let i = span.start; i < span.end; i++) {
+				map.set(i, span);
+			}
+		}
+		return map;
+	});
+
+	// Group tokens by turn span for rendering
+	interface TokenGroup {
+		span: TurnSpan | null;
+		tokens: TokenProjection[];
+	}
+
+	let tokenGroups = $derived.by((): TokenGroup[] => {
+		if (response.spans.length === 0) {
+			// Raw text mode: single group with no span
+			return [{ span: null, tokens: response.tokens }];
+		}
+
+		const groups: TokenGroup[] = [];
+		let currentSpan: TurnSpan | null = null;
+		let currentTokens: TokenProjection[] = [];
+
+		for (const token of response.tokens) {
+			const span = spanByPosition.get(token.position) ?? null;
+			if (span !== currentSpan) {
+				if (currentTokens.length > 0) {
+					groups.push({ span: currentSpan, tokens: currentTokens });
+				}
+				currentSpan = span;
+				currentTokens = [token];
+			} else {
+				currentTokens.push(token);
+			}
+		}
+		if (currentTokens.length > 0) {
+			groups.push({ span: currentSpan, tokens: currentTokens });
+		}
+		return groups;
+	});
+
+	/**
+	 * Map a projection value to a diverging color.
+	 * High projection (assistant-like) -> blue (hsl 210)
+	 * Low projection (drifted) -> red (hsl 0)
+	 * Middle -> neutral gray
+	 */
+	function projectionColor(value: number): string {
+		const { min, max } = extent;
+		const range = max - min;
+		if (range === 0) return 'hsla(210, 10%, 30%, 0.3)';
+
+		// Normalize to 0..1
+		const t = (value - min) / range;
+
+		// Interpolate hue: 0 (red) at t=0, 210 (blue) at t=1
+		const hue = t * 210;
+		// Saturation peaks at extremes, lower in the middle
+		const distFromCenter = Math.abs(t - 0.5) * 2; // 0 at center, 1 at extremes
+		const saturation = 30 + distFromCenter * 50;
+		// Lightness: keep readable on dark theme
+		const lightness = 25 + distFromCenter * 15;
+		const alpha = 0.4 + distFromCenter * 0.4;
+
+		return `hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha})`;
+	}
+
+	/** Check if a token string is a special/control token */
+	function isSpecialToken(str: string): boolean {
+		return str.startsWith('<|') && str.endsWith('|>');
+	}
+
+	/** Check if a token represents a newline */
+	function isNewline(str: string): boolean {
+		return str === '\n' || str === '\r\n' || str === '\r' || str === '\u010a';
+	}
+
+	/** Check if a token is purely whitespace (but not a newline) */
+	function isWhitespace(str: string): boolean {
+		return /^\s+$/.test(str) && !isNewline(str);
+	}
+
+	/** Role label display text */
+	function roleLabel(role: string): string {
+		return role.charAt(0).toUpperCase() + role.slice(1);
+	}
+
+	/** Role label CSS class */
+	function roleClass(role: string): string {
+		switch (role) {
+			case 'assistant':
+				return 'role-assistant';
+			case 'user':
+				return 'role-user';
+			case 'system':
+				return 'role-system';
+			default:
+				return 'role-other';
+		}
+	}
+
+	function handleMouseMove(e: MouseEvent) {
+		tooltipX = e.clientX;
+		tooltipY = e.clientY;
+	}
+
+	function handleTokenEnter(token: TokenProjection) {
+		hoveredToken = token;
+		hoveredTurn = spanByPosition.get(token.position) ?? null;
+	}
+
+	function handleTokenLeave() {
+		hoveredToken = null;
+		hoveredTurn = null;
+	}
+
+	// Color legend gradient stops
+	let legendStops = $derived.by(() => {
+		const stops: string[] = [];
+		const steps = 20;
+		for (let i = 0; i <= steps; i++) {
+			const t = i / steps;
+			const value = extent.min + t * (extent.max - extent.min);
+			stops.push(projectionColor(value));
+		}
+		return stops;
+	});
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="heatmap-container" onmousemove={handleMouseMove}>
+	<!-- Color scale legend -->
+	<div class="legend">
+		<span class="legend-label">{extent.min.toFixed(3)}</span>
+		<div class="legend-bar">
+			{#each legendStops as color, i}
+				<div
+					class="legend-segment"
+					style="background: {color}; width: {100 / legendStops.length}%;"
+				></div>
+			{/each}
+		</div>
+		<span class="legend-label">{extent.max.toFixed(3)}</span>
+		<span class="legend-desc">low (red) --- high (blue)</span>
+	</div>
+
+	<!-- Token groups by turn -->
+	{#each tokenGroups as group}
+		<div class="turn-block">
+			{#if group.span}
+				<div class="turn-header">
+					<span class="role-label {roleClass(group.span.role)}">
+						{roleLabel(group.span.role)}
+					</span>
+					<span class="turn-meta">
+						turn {group.span.turn} | mean: {group.span.mean_projection.toFixed(4)}
+					</span>
+				</div>
+			{/if}
+			<div class="token-flow">
+				{#each group.tokens as token (token.position)}
+					{#if isNewline(token.token_str)}
+						<br />
+					{:else if isSpecialToken(token.token_str)}
+						<span
+							class="token special"
+							onmouseenter={() => handleTokenEnter(token)}
+							onmouseleave={handleTokenLeave}
+							role="presentation"
+						>{token.token_str}</span>
+					{:else if isWhitespace(token.token_str)}
+						<span
+							class="token whitespace"
+							style="background: {projectionColor(token.projection)};"
+							onmouseenter={() => handleTokenEnter(token)}
+							onmouseleave={handleTokenLeave}
+							role="presentation"
+						>&nbsp;</span>
+					{:else}
+						<span
+							class="token"
+							style="background: {projectionColor(token.projection)};"
+							onmouseenter={() => handleTokenEnter(token)}
+							onmouseleave={handleTokenLeave}
+							role="presentation"
+						>{token.token_str}</span>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	{/each}
+
+	<Tooltip x={tooltipX} y={tooltipY} visible={hoveredToken !== null}>
+		{#if hoveredToken}
+			<div class="tip-token">
+				<strong>"{hoveredToken.token_str}"</strong>
+			</div>
+			<div class="tip-detail">projection: {hoveredToken.projection.toFixed(4)}</div>
+			<div class="tip-detail">position: {hoveredToken.position}</div>
+			<div class="tip-detail">token_id: {hoveredToken.token_id}</div>
+			{#if hoveredTurn}
+				<div class="tip-detail">
+					turn {hoveredTurn.turn} ({hoveredTurn.role})
+				</div>
+			{/if}
+		{/if}
+	</Tooltip>
+</div>
+
+<style>
+	.heatmap-container {
+		position: relative;
+	}
+
+	/* Color legend */
+	.legend {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+		padding: 0.5rem 0;
+		border-bottom: 1px solid var(--border);
+	}
+	.legend-bar {
+		display: flex;
+		flex: 1;
+		height: 12px;
+		border-radius: 3px;
+		overflow: hidden;
+		max-width: 300px;
+	}
+	.legend-segment {
+		height: 100%;
+	}
+	.legend-label {
+		font-size: 0.7rem;
+		color: var(--text-muted);
+		font-family: monospace;
+		white-space: nowrap;
+	}
+	.legend-desc {
+		font-size: 0.7rem;
+		color: var(--text-muted);
+		margin-left: 0.5rem;
+	}
+
+	/* Turn blocks */
+	.turn-block {
+		margin-bottom: 0.75rem;
+		padding: 0.5rem;
+		border-left: 3px solid var(--border);
+		border-radius: 2px;
+	}
+	.turn-block:not(:last-child) {
+		border-bottom: 1px solid var(--border);
+		padding-bottom: 0.75rem;
+	}
+	.turn-header {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 0.35rem;
+	}
+	.role-label {
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 0.1rem 0.4rem;
+		border-radius: 3px;
+	}
+	.role-assistant {
+		color: var(--warning);
+		background: rgba(255, 167, 38, 0.1);
+	}
+	.role-user {
+		color: var(--primary);
+		background: rgba(79, 195, 247, 0.1);
+	}
+	.role-system {
+		color: var(--text-muted);
+		background: rgba(136, 146, 164, 0.1);
+	}
+	.role-other {
+		color: var(--text-muted);
+	}
+	.turn-meta {
+		font-size: 0.7rem;
+		color: var(--text-muted);
+		font-family: monospace;
+	}
+
+	/* Token flow */
+	.token-flow {
+		line-height: 1.8;
+		font-family: 'Fira Code', 'Cascadia Code', monospace;
+		font-size: 0.85rem;
+	}
+	.token {
+		display: inline;
+		padding: 0.1rem 0;
+		border-radius: 2px;
+		cursor: default;
+		transition: outline 0.1s;
+	}
+	.token:hover {
+		outline: 1px solid var(--primary);
+		outline-offset: 1px;
+	}
+	.token.special {
+		color: var(--text-muted);
+		opacity: 0.4;
+		font-size: 0.7rem;
+	}
+	.token.whitespace {
+		display: inline-block;
+		min-width: 0.3em;
+	}
+
+	/* Tooltip details */
+	.tip-token {
+		margin-bottom: 0.25rem;
+		font-family: monospace;
+	}
+	.tip-detail {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin-bottom: 0.1rem;
+	}
+</style>

--- a/axis-viewer/frontend/src/lib/components/Tooltip.svelte
+++ b/axis-viewer/frontend/src/lib/components/Tooltip.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		x,
+		y,
+		visible,
+		children
+	}: {
+		x: number;
+		y: number;
+		visible: boolean;
+		children: Snippet;
+	} = $props();
+</script>
+
+{#if visible}
+	<div class="tooltip" style="left: {x + 12}px; top: {y + 12}px;">
+		{@render children()}
+	</div>
+{/if}
+
+<style>
+	.tooltip {
+		position: fixed;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		padding: 0.5rem 0.75rem;
+		max-width: 320px;
+		pointer-events: none;
+		z-index: 100;
+		font-size: 0.8rem;
+		line-height: 1.4;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	}
+</style>

--- a/axis-viewer/frontend/src/lib/components/TrajectoryChart.svelte
+++ b/axis-viewer/frontend/src/lib/components/TrajectoryChart.svelte
@@ -1,0 +1,367 @@
+<script lang="ts">
+	import type { TurnSpan } from '$lib/types';
+	import Tooltip from './Tooltip.svelte';
+
+	let { spans }: { spans: TurnSpan[] } = $props();
+
+	// SVG dimensions
+	const width = 600;
+	const height = 300;
+	const padding = { top: 30, right: 30, bottom: 40, left: 60 };
+
+	// Tooltip state
+	let tooltipX = $state(0);
+	let tooltipY = $state(0);
+	let hoveredSpan = $state<TurnSpan | null>(null);
+
+	// Sort spans by turn index
+	let sortedSpans = $derived([...spans].sort((a, b) => a.turn - b.turn));
+
+	// Axis extents
+	let xExtent = $derived.by((): [number, number] => {
+		if (sortedSpans.length === 0) return [0, 1];
+		const turns = sortedSpans.map((s) => s.turn);
+		return [Math.min(...turns), Math.max(...turns)];
+	});
+
+	let yExtent = $derived.by((): [number, number] => {
+		if (sortedSpans.length === 0) return [0, 1];
+		const vals = sortedSpans.map((s) => s.mean_projection);
+		const min = Math.min(...vals);
+		const max = Math.max(...vals);
+		const range = max - min || 1;
+		return [min - range * 0.1, max + range * 0.1];
+	});
+
+	// Scale functions
+	function scaleX(turn: number): number {
+		const [min, max] = xExtent;
+		const range = max - min || 1;
+		return padding.left + ((turn - min) / range) * (width - padding.left - padding.right);
+	}
+
+	function scaleY(val: number): number {
+		const [min, max] = yExtent;
+		const range = max - min || 1;
+		return (
+			height - padding.bottom - ((val - min) / range) * (height - padding.top - padding.bottom)
+		);
+	}
+
+	// Build line path
+	let linePath = $derived.by(() => {
+		if (sortedSpans.length === 0) return '';
+		return sortedSpans
+			.map((s, i) => {
+				const x = scaleX(s.turn);
+				const y = scaleY(s.mean_projection);
+				return `${i === 0 ? 'M' : 'L'} ${x} ${y}`;
+			})
+			.join(' ');
+	});
+
+	// Grid lines for Y axis (5 ticks)
+	let yTicks = $derived.by(() => {
+		const [min, max] = yExtent;
+		const step = (max - min) / 4;
+		return Array.from({ length: 5 }, (_, i) => min + i * step);
+	});
+
+	// Grid lines for X axis (turn indices)
+	let xTicks = $derived.by(() => {
+		if (sortedSpans.length <= 1) return sortedSpans.map((s) => s.turn);
+		const [min, max] = xExtent;
+		// Show every turn if few, otherwise sample
+		const allTurns = sortedSpans.map((s) => s.turn);
+		if (allTurns.length <= 10) return allTurns;
+		// Sample roughly 8 ticks
+		const step = Math.max(1, Math.floor((max - min) / 7));
+		const ticks: number[] = [];
+		for (let t = min; t <= max; t += step) {
+			ticks.push(t);
+		}
+		if (ticks[ticks.length - 1] !== max) ticks.push(max);
+		return ticks;
+	});
+
+	// Point color by role
+	function roleColor(role: string): string {
+		switch (role) {
+			case 'user':
+				return 'var(--primary)';
+			case 'assistant':
+				return 'var(--warning)';
+			case 'system':
+				return 'var(--text-muted)';
+			default:
+				return 'var(--text)';
+		}
+	}
+
+	function handleMouseMove(e: MouseEvent) {
+		tooltipX = e.clientX;
+		tooltipY = e.clientY;
+	}
+
+	function truncate(text: string, maxLen: number): string {
+		if (text.length <= maxLen) return text;
+		return text.slice(0, maxLen) + '...';
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="chart-container" onmousemove={handleMouseMove}>
+	{#if sortedSpans.length === 0}
+		<p class="empty">No turn data to display.</p>
+	{:else}
+		<svg viewBox="0 0 {width} {height}" class="chart-svg">
+			<!-- Y-axis grid lines and labels -->
+			{#each yTicks as tick}
+				<line
+					x1={padding.left}
+					y1={scaleY(tick)}
+					x2={width - padding.right}
+					y2={scaleY(tick)}
+					class="grid-line"
+				/>
+				<text
+					x={padding.left - 8}
+					y={scaleY(tick) + 4}
+					class="axis-tick"
+					text-anchor="end"
+				>{tick.toFixed(3)}</text>
+			{/each}
+
+			<!-- X-axis grid lines and labels -->
+			{#each xTicks as tick}
+				<line
+					x1={scaleX(tick)}
+					y1={padding.top}
+					x2={scaleX(tick)}
+					y2={height - padding.bottom}
+					class="grid-line"
+				/>
+				<text
+					x={scaleX(tick)}
+					y={height - padding.bottom + 16}
+					class="axis-tick"
+					text-anchor="middle"
+				>{tick}</text>
+			{/each}
+
+			<!-- Axes -->
+			<line
+				x1={padding.left}
+				y1={height - padding.bottom}
+				x2={width - padding.right}
+				y2={height - padding.bottom}
+				class="axis"
+			/>
+			<line
+				x1={padding.left}
+				y1={padding.top}
+				x2={padding.left}
+				y2={height - padding.bottom}
+				class="axis"
+			/>
+
+			<!-- Reference line (dashed) for typical assistant range -->
+			{#if yExtent[0] <= 0 && yExtent[1] >= 0}
+				<line
+					x1={padding.left}
+					y1={scaleY(0)}
+					x2={width - padding.right}
+					y2={scaleY(0)}
+					class="reference-line"
+				/>
+				<text
+					x={width - padding.right + 4}
+					y={scaleY(0) + 4}
+					class="reference-label"
+				>baseline</text>
+			{/if}
+
+			<!-- Connecting line -->
+			<path d={linePath} class="trajectory-line" />
+
+			<!-- Data points -->
+			{#each sortedSpans as span}
+				<circle
+					cx={scaleX(span.turn)}
+					cy={scaleY(span.mean_projection)}
+					r={hoveredSpan === span ? 8 : 6}
+					fill={roleColor(span.role)}
+					class="point"
+					class:hovered={hoveredSpan === span}
+					onmouseenter={() => { hoveredSpan = span; }}
+					onmouseleave={() => { hoveredSpan = null; }}
+					role="button"
+					tabindex="0"
+				/>
+			{/each}
+
+			<!-- Axis labels -->
+			<text
+				x={(padding.left + width - padding.right) / 2}
+				y={height - 4}
+				class="axis-label"
+			>Turn</text>
+			<text
+				x={14}
+				y={(padding.top + height - padding.bottom) / 2}
+				class="axis-label"
+				transform="rotate(-90, 14, {(padding.top + height - padding.bottom) / 2})"
+			>Mean Projection</text>
+		</svg>
+
+		<!-- Legend -->
+		<div class="legend">
+			<span class="legend-item">
+				<span class="legend-dot" style="background: var(--primary);"></span>
+				User
+			</span>
+			<span class="legend-item">
+				<span class="legend-dot" style="background: var(--warning);"></span>
+				Assistant
+			</span>
+			<span class="legend-item">
+				<span class="legend-dot" style="background: var(--text-muted);"></span>
+				System
+			</span>
+		</div>
+	{/if}
+
+	<Tooltip x={tooltipX} y={tooltipY} visible={hoveredSpan !== null}>
+		{#if hoveredSpan}
+			<div class="tip-turn">
+				<strong>Turn {hoveredSpan.turn}</strong>
+				<span class="tip-role" style="color: {roleColor(hoveredSpan.role)}">
+					{hoveredSpan.role}
+				</span>
+			</div>
+			<div class="tip-projection">
+				mean projection: {hoveredSpan.mean_projection.toFixed(4)}
+			</div>
+			<div class="tip-text">{truncate(hoveredSpan.text, 100)}</div>
+		{/if}
+	</Tooltip>
+</div>
+
+<style>
+	.chart-container {
+		position: relative;
+		width: 100%;
+	}
+	.chart-svg {
+		width: 100%;
+		max-width: 700px;
+		display: block;
+	}
+	.empty {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 2rem;
+	}
+
+	/* Grid and axes */
+	.grid-line {
+		stroke: var(--border);
+		stroke-width: 0.5;
+		opacity: 0.4;
+	}
+	.axis {
+		stroke: var(--text-muted);
+		stroke-width: 1;
+	}
+	.axis-tick {
+		fill: var(--text-muted);
+		font-size: 9px;
+		font-family: monospace;
+	}
+	.axis-label {
+		fill: var(--text-muted);
+		font-size: 11px;
+		text-anchor: middle;
+	}
+
+	/* Reference line */
+	.reference-line {
+		stroke: var(--text-muted);
+		stroke-width: 1;
+		stroke-dasharray: 6 3;
+		opacity: 0.5;
+	}
+	.reference-label {
+		fill: var(--text-muted);
+		font-size: 9px;
+		font-style: italic;
+	}
+
+	/* Trajectory */
+	.trajectory-line {
+		fill: none;
+		stroke: var(--text-muted);
+		stroke-width: 1.5;
+		opacity: 0.5;
+	}
+	.point {
+		cursor: pointer;
+		stroke: var(--bg);
+		stroke-width: 2;
+		transition:
+			r 0.15s,
+			stroke-width 0.15s;
+		opacity: 0.9;
+	}
+	.point:hover,
+	.point.hovered {
+		opacity: 1;
+		stroke: var(--text);
+		stroke-width: 2.5;
+	}
+
+	/* Legend */
+	.legend {
+		display: flex;
+		gap: 1rem;
+		margin-top: 0.5rem;
+		padding: 0.25rem 0;
+	}
+	.legend-item {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+	.legend-dot {
+		display: inline-block;
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+	}
+
+	/* Tooltip details */
+	.tip-turn {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 0.25rem;
+	}
+	.tip-role {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		font-weight: 600;
+	}
+	.tip-projection {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		font-family: monospace;
+		margin-bottom: 0.25rem;
+	}
+	.tip-text {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		line-height: 1.3;
+	}
+</style>

--- a/axis-viewer/frontend/src/lib/types.ts
+++ b/axis-viewer/frontend/src/lib/types.ts
@@ -1,3 +1,28 @@
 /**
  * Shared TypeScript types for the axis-viewer frontend.
+ *
+ * These mirror the Pydantic models in backend/models.py.
  */
+
+export interface TokenProjection {
+	token_id: number;
+	token_str: string;
+	projection: number;
+	position: number;
+}
+
+export interface TurnSpan {
+	turn: number;
+	role: string;
+	start: number;
+	end: number;
+	text: string;
+	mean_projection: number;
+}
+
+export interface ProjectionResponse {
+	tokens: TokenProjection[];
+	spans: TurnSpan[];
+	layer: number;
+	model_name: string;
+}


### PR DESCRIPTION
## Summary

- Added TypeScript interfaces (`TokenProjection`, `TurnSpan`, `ProjectionResponse`) to `types.ts` mirroring the backend Pydantic models
- Added `projectChat` and `projectRaw` API client functions to `api.ts`
- Created `TokenHeatmap.svelte` - renders per-token text with diverging color backgrounds (blue=high/assistant-like, red=low/drifted), grouped by turn with role labels, hover tooltips, and a color scale legend
- Created `TrajectoryChart.svelte` - pure SVG line chart showing per-turn mean projection values with role-colored points, gridlines, axis labels, baseline reference line, and hover tooltips
- Created shared `Tooltip.svelte` component

All components use Svelte 5 runes (`$props()`, `$state()`, `$derived()`), follow the dark theme CSS variables, and pass `svelte-check` with zero errors/warnings.

Closes #14

## Test plan
- [ ] Import `TokenHeatmap` with mock `ProjectionResponse` data and verify tokens render with correct diverging colors
- [ ] Verify turn boundaries show role labels (User/Assistant/System) with visual separators
- [ ] Hover over tokens and confirm tooltip shows token string, projection, position, and turn info
- [ ] Verify color legend renders with correct min/max values
- [ ] Import `TrajectoryChart` with mock `TurnSpan[]` and verify line chart renders correctly
- [ ] Hover over chart points and confirm tooltip shows turn number, role, text preview, and mean projection
- [ ] Test edge cases: empty spans (raw text mode), single turn, special tokens
- [ ] Run `npm run build` and `npm run check` - both pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)