### PR TITLE
axis-viewer: Chat mode with generation & conversation editing (#15)

### DIFF
--- a/axis-viewer/backend/app.py
+++ b/axis-viewer/backend/app.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from huggingface_hub import hf_hub_download
 
 from backend.config import AxisViewerConfig, load_config
+from backend.routes.generate import router as generate_router
 from backend.routes.project import router as project_router
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,7 @@ def create_app(config_path: str = "config.yaml") -> FastAPI:
             "total_layers": config.total_layers,
         }
 
+    app.include_router(generate_router)
     app.include_router(project_router)
 
     return app

--- a/axis-viewer/backend/models.py
+++ b/axis-viewer/backend/models.py
@@ -34,3 +34,13 @@ class ChatRequest(BaseModel):
 
 class RawTextRequest(BaseModel):
     text: str
+
+
+class GenerateRequest(BaseModel):
+    conversation: list[dict]  # [{"role": "user", "content": "..."}, ...]
+    temperature: float = 0.7
+    max_new_tokens: int = 512
+
+
+class GenerateResponse(BaseModel):
+    content: str

--- a/axis-viewer/backend/routes/generate.py
+++ b/axis-viewer/backend/routes/generate.py
@@ -1,0 +1,54 @@
+"""Generation endpoint: generate assistant responses using ProbingModel."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+
+from backend.models import GenerateRequest, GenerateResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["generate"])
+
+
+MOCK_RESPONSE = "This is a mock assistant response."
+
+
+def _generate_response(
+    request: Request,
+    conversation: list[dict],
+    temperature: float,
+    max_new_tokens: int,
+) -> str:
+    """Run generation on the model. Blocking -- call via asyncio.to_thread."""
+    probing_model = request.app.state.probing_model
+    return probing_model.generate(
+        conversation,
+        enable_thinking=False,
+        temperature=temperature,
+        max_new_tokens=max_new_tokens,
+    )
+
+
+@router.post("/generate", response_model=GenerateResponse)
+async def generate(body: GenerateRequest, request: Request):
+    """Generate an assistant response for the given conversation."""
+    config = request.app.state.config
+
+    if config.mock_model:
+        return GenerateResponse(content=MOCK_RESPONSE)
+
+    if request.app.state.probing_model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    content = await asyncio.to_thread(
+        _generate_response,
+        request,
+        body.conversation,
+        body.temperature,
+        body.max_new_tokens,
+    )
+    return GenerateResponse(content=content)

--- a/axis-viewer/frontend/src/lib/api.ts
+++ b/axis-viewer/frontend/src/lib/api.ts
@@ -37,3 +37,18 @@ export async function projectRaw(text: string): Promise<ProjectionResponse> {
 		body: JSON.stringify({ text })
 	});
 }
+
+export async function generate(
+	conversation: Array<{ role: string; content: string }>,
+	temperature: number = 0.7,
+	maxNewTokens: number = 512
+): Promise<{ content: string }> {
+	return request<{ content: string }>('/generate', {
+		method: 'POST',
+		body: JSON.stringify({
+			conversation,
+			temperature,
+			max_new_tokens: maxNewTokens
+		})
+	});
+}

--- a/axis-viewer/frontend/src/routes/chat/+page.svelte
+++ b/axis-viewer/frontend/src/routes/chat/+page.svelte
@@ -1,9 +1,683 @@
-<p class="placeholder">Chat mode coming soon</p>
+<script lang="ts">
+	import { generate, projectChat } from '$lib/api';
+	import TokenHeatmap from '$lib/components/TokenHeatmap.svelte';
+	import TrajectoryChart from '$lib/components/TrajectoryChart.svelte';
+	import type { ProjectionResponse } from '$lib/types';
+
+	// ---- State ----
+
+	interface Message {
+		role: 'user' | 'assistant' | 'system';
+		content: string;
+	}
+
+	let messages = $state<Message[]>([]);
+	let inputText = $state('');
+	let systemPrompt = $state('');
+	let systemPromptOpen = $state(false);
+	let temperature = $state(0.7);
+	let maxTokens = $state(512);
+
+	// Loading states
+	let generating = $state(false);
+	let projecting = $state(false);
+	let statusText = $state('');
+
+	// Projection result
+	let projectionResponse = $state<ProjectionResponse | null>(null);
+
+	// Editing state
+	let editingIndex = $state<number | null>(null);
+	let editingContent = $state('');
+
+	// Insert state
+	let insertAtIndex = $state<number | null>(null);
+	let insertRole = $state<'user' | 'assistant'>('user');
+	let insertContent = $state('');
+
+	// Error state
+	let errorMessage = $state('');
+
+	// Scroll ref
+	let messagesContainer: HTMLDivElement | undefined = $state(undefined);
+
+	// ---- Helpers ----
+
+	function buildConversation(): Array<{ role: string; content: string }> {
+		const conv: Array<{ role: string; content: string }> = [];
+		if (systemPrompt.trim()) {
+			conv.push({ role: 'system', content: systemPrompt.trim() });
+		}
+		for (const msg of messages) {
+			conv.push({ role: msg.role, content: msg.content });
+		}
+		return conv;
+	}
+
+	function scrollToBottom() {
+		// Use tick-like delay to let DOM update
+		setTimeout(() => {
+			if (messagesContainer) {
+				messagesContainer.scrollTop = messagesContainer.scrollHeight;
+			}
+		}, 0);
+	}
+
+	async function updateProjections() {
+		const conv = buildConversation();
+		if (conv.length === 0) {
+			projectionResponse = null;
+			return;
+		}
+		projecting = true;
+		statusText = 'Computing projections...';
+		errorMessage = '';
+		try {
+			projectionResponse = await projectChat(conv);
+		} catch (e) {
+			errorMessage = `Projection error: ${e instanceof Error ? e.message : String(e)}`;
+		} finally {
+			projecting = false;
+			statusText = '';
+		}
+	}
+
+	// ---- Actions ----
+
+	async function sendMessage() {
+		const text = inputText.trim();
+		if (!text || generating) return;
+
+		errorMessage = '';
+		messages.push({ role: 'user', content: text });
+		inputText = '';
+		scrollToBottom();
+
+		// Generate assistant response
+		generating = true;
+		statusText = 'Generating response...';
+		try {
+			const conv = buildConversation();
+			const result = await generate(conv, temperature, maxTokens);
+			messages.push({ role: 'assistant', content: result.content });
+			scrollToBottom();
+		} catch (e) {
+			errorMessage = `Generation error: ${e instanceof Error ? e.message : String(e)}`;
+			generating = false;
+			statusText = '';
+			return;
+		}
+		generating = false;
+
+		// Get projections
+		await updateProjections();
+	}
+
+	function handleInputKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			sendMessage();
+		}
+	}
+
+	// Edit message
+	function startEditing(index: number) {
+		editingIndex = index;
+		editingContent = messages[index].content;
+	}
+
+	async function saveEdit() {
+		if (editingIndex === null) return;
+		messages[editingIndex].content = editingContent;
+		editingIndex = null;
+		editingContent = '';
+		await updateProjections();
+	}
+
+	function cancelEdit() {
+		editingIndex = null;
+		editingContent = '';
+	}
+
+	// Delete message
+	async function deleteMessage(index: number) {
+		messages.splice(index, 1);
+		// Trigger reactivity
+		messages = [...messages];
+		await updateProjections();
+	}
+
+	// Insert message
+	function startInsert(index: number) {
+		insertAtIndex = index;
+		insertRole = 'user';
+		insertContent = '';
+	}
+
+	async function confirmInsert() {
+		if (insertAtIndex === null || !insertContent.trim()) return;
+		messages.splice(insertAtIndex, 0, {
+			role: insertRole,
+			content: insertContent.trim()
+		});
+		messages = [...messages];
+		insertAtIndex = null;
+		insertContent = '';
+		await updateProjections();
+	}
+
+	function cancelInsert() {
+		insertAtIndex = null;
+		insertContent = '';
+	}
+
+	// Clear all
+	async function clearAll() {
+		messages = [];
+		projectionResponse = null;
+		editingIndex = null;
+		insertAtIndex = null;
+		errorMessage = '';
+	}
+
+	let busy = $derived(generating || projecting);
+</script>
+
+<div class="chat-layout">
+	<!-- Left panel: conversation -->
+	<div class="chat-panel">
+		<!-- System prompt (collapsible) -->
+		<div class="system-prompt-section">
+			<button
+				class="system-prompt-toggle"
+				onclick={() => (systemPromptOpen = !systemPromptOpen)}
+			>
+				<span class="toggle-arrow" class:open={systemPromptOpen}>&#9654;</span>
+				System Prompt
+			</button>
+			{#if systemPromptOpen}
+				<textarea
+					class="system-prompt-input"
+					placeholder="Optional system prompt..."
+					bind:value={systemPrompt}
+					rows="3"
+				></textarea>
+			{/if}
+		</div>
+
+		<!-- Generation controls -->
+		<div class="controls">
+			<label class="control-item">
+				<span class="control-label">Temperature: {temperature.toFixed(2)}</span>
+				<input
+					type="range"
+					min="0"
+					max="1.5"
+					step="0.05"
+					bind:value={temperature}
+				/>
+			</label>
+			<label class="control-item">
+				<span class="control-label">Max tokens: {maxTokens}</span>
+				<input
+					type="range"
+					min="64"
+					max="2048"
+					step="64"
+					bind:value={maxTokens}
+				/>
+			</label>
+			{#if messages.length > 0}
+				<button class="danger clear-btn" onclick={clearAll}>Clear All</button>
+			{/if}
+		</div>
+
+		<!-- Messages -->
+		<div class="messages" bind:this={messagesContainer}>
+			{#if messages.length === 0}
+				<p class="empty-state">Send a message to start a conversation.</p>
+			{/if}
+
+			{#each messages as msg, i (i)}
+				<!-- Insert button above this message -->
+				{#if insertAtIndex === i}
+					<div class="insert-form">
+						<div class="insert-header">
+							<select bind:value={insertRole}>
+								<option value="user">User</option>
+								<option value="assistant">Assistant</option>
+							</select>
+							<button class="small" onclick={confirmInsert}>Insert</button>
+							<button class="small" onclick={cancelInsert}>Cancel</button>
+						</div>
+						<textarea
+							class="insert-textarea"
+							placeholder="Message content..."
+							bind:value={insertContent}
+							rows="2"
+						></textarea>
+					</div>
+				{:else}
+					<button
+						class="insert-btn"
+						title="Insert message here"
+						onclick={() => startInsert(i)}
+					>+</button>
+				{/if}
+
+				<div class="message" class:user={msg.role === 'user'} class:assistant={msg.role === 'assistant'}>
+					<div class="message-header">
+						<span class="role-tag {msg.role}">{msg.role}</span>
+						<div class="message-actions">
+							{#if editingIndex !== i}
+								<button class="icon-btn" title="Edit" onclick={() => startEditing(i)}>&#9998;</button>
+								<button class="icon-btn danger-text" title="Delete" onclick={() => deleteMessage(i)}>&times;</button>
+							{/if}
+						</div>
+					</div>
+					{#if editingIndex === i}
+						<textarea
+							class="edit-textarea"
+							bind:value={editingContent}
+							rows="4"
+						></textarea>
+						<div class="edit-actions">
+							<button class="small primary" onclick={saveEdit}>Save</button>
+							<button class="small" onclick={cancelEdit}>Cancel</button>
+						</div>
+					{:else}
+						<div class="message-content">{msg.content}</div>
+					{/if}
+				</div>
+			{/each}
+
+			<!-- Insert at end -->
+			{#if messages.length > 0}
+				{#if insertAtIndex === messages.length}
+					<div class="insert-form">
+						<div class="insert-header">
+							<select bind:value={insertRole}>
+								<option value="user">User</option>
+								<option value="assistant">Assistant</option>
+							</select>
+							<button class="small" onclick={confirmInsert}>Insert</button>
+							<button class="small" onclick={cancelInsert}>Cancel</button>
+						</div>
+						<textarea
+							class="insert-textarea"
+							placeholder="Message content..."
+							bind:value={insertContent}
+							rows="2"
+						></textarea>
+					</div>
+				{:else}
+					<button
+						class="insert-btn"
+						title="Insert message here"
+						onclick={() => startInsert(messages.length)}
+					>+</button>
+				{/if}
+			{/if}
+
+			<!-- Loading indicator -->
+			{#if busy}
+				<div class="loading">
+					<span class="spinner"></span>
+					<span>{statusText}</span>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Error display -->
+		{#if errorMessage}
+			<div class="error-bar">{errorMessage}</div>
+		{/if}
+
+		<!-- Input area -->
+		<div class="input-area">
+			<textarea
+				class="message-input"
+				placeholder="Type a message... (Enter to send, Shift+Enter for newline)"
+				bind:value={inputText}
+				onkeydown={handleInputKeydown}
+				rows="2"
+				disabled={busy}
+			></textarea>
+			<button class="primary send-btn" onclick={sendMessage} disabled={busy || !inputText.trim()}>
+				{generating ? 'Generating...' : 'Send'}
+			</button>
+		</div>
+	</div>
+
+	<!-- Right panel: visualizations -->
+	<div class="viz-panel">
+		{#if projectionResponse}
+			<div class="viz-section heatmap-scroll">
+				<h3 class="viz-title">Token Heatmap</h3>
+				<TokenHeatmap response={projectionResponse} />
+			</div>
+			<div class="viz-section">
+				<h3 class="viz-title">Trajectory</h3>
+				<TrajectoryChart spans={projectionResponse.spans} />
+			</div>
+		{:else}
+			<p class="viz-placeholder">
+				Projections will appear here after the first assistant response.
+			</p>
+		{/if}
+	</div>
+</div>
 
 <style>
-	.placeholder {
+	/* Layout */
+	.chat-layout {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1.5rem;
+		height: calc(100vh - 100px);
+		min-height: 500px;
+	}
+
+	/* Chat panel */
+	.chat-panel {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+	}
+
+	/* System prompt */
+	.system-prompt-section {
+		margin-bottom: 0.5rem;
+	}
+	.system-prompt-toggle {
+		background: none;
+		border: none;
 		color: var(--text-muted);
-		padding: 2rem;
+		font-size: 0.8rem;
+		padding: 0.25rem 0;
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+	.system-prompt-toggle:hover {
+		color: var(--text);
+		background: none;
+	}
+	.toggle-arrow {
+		display: inline-block;
+		font-size: 0.6rem;
+		transition: transform 0.15s;
+	}
+	.toggle-arrow.open {
+		transform: rotate(90deg);
+	}
+	.system-prompt-input {
+		width: 100%;
+		margin-top: 0.25rem;
+		resize: vertical;
+		font-family: inherit;
+	}
+
+	/* Controls */
+	.controls {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		padding: 0.5rem 0;
+		border-bottom: 1px solid var(--border);
+		margin-bottom: 0.5rem;
+		flex-wrap: wrap;
+	}
+	.control-item {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+	.control-label {
+		white-space: nowrap;
+		min-width: 6rem;
+	}
+	.control-item input[type='range'] {
+		width: 100px;
+		accent-color: var(--primary);
+	}
+	.clear-btn {
+		margin-left: auto;
+		padding: 0.3rem 0.6rem;
+		font-size: 0.75rem;
+	}
+
+	/* Messages area */
+	.messages {
+		flex: 1;
+		overflow-y: auto;
+		padding: 0.5rem 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	.empty-state {
+		color: var(--text-muted);
 		text-align: center;
+		padding: 3rem 1rem;
+		font-size: 0.9rem;
+	}
+
+	/* Message */
+	.message {
+		padding: 0.6rem 0.75rem;
+		border-radius: 6px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.message.user {
+		border-left: 3px solid var(--primary);
+	}
+	.message.assistant {
+		border-left: 3px solid var(--warning);
+	}
+	.message-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 0.3rem;
+	}
+	.role-tag {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 0.1rem 0.4rem;
+		border-radius: 3px;
+	}
+	.role-tag.user {
+		color: var(--primary);
+		background: rgba(79, 195, 247, 0.1);
+	}
+	.role-tag.assistant {
+		color: var(--warning);
+		background: rgba(255, 167, 38, 0.1);
+	}
+	.role-tag.system {
+		color: var(--text-muted);
+		background: rgba(136, 146, 164, 0.1);
+	}
+	.message-actions {
+		display: flex;
+		gap: 0.25rem;
+	}
+	.icon-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1rem;
+		padding: 0.1rem 0.3rem;
+		line-height: 1;
+		cursor: pointer;
+		border-radius: 3px;
+	}
+	.icon-btn:hover {
+		background: var(--surface-hover);
+		color: var(--text);
+	}
+	.icon-btn.danger-text:hover {
+		color: var(--danger);
+	}
+	.message-content {
+		font-size: 0.875rem;
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	/* Edit mode */
+	.edit-textarea {
+		width: 100%;
+		resize: vertical;
+		font-family: inherit;
+		font-size: 0.875rem;
+		margin-bottom: 0.35rem;
+	}
+	.edit-actions {
+		display: flex;
+		gap: 0.35rem;
+	}
+	button.small {
+		padding: 0.25rem 0.5rem;
+		font-size: 0.75rem;
+	}
+
+	/* Insert controls */
+	.insert-btn {
+		align-self: center;
+		background: none;
+		border: 1px dashed var(--border);
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		padding: 0 0.5rem;
+		line-height: 1.4;
+		border-radius: 3px;
+		opacity: 0;
+		transition: opacity 0.15s;
+	}
+	.messages:hover .insert-btn {
+		opacity: 0.6;
+	}
+	.insert-btn:hover {
+		opacity: 1 !important;
+		border-color: var(--primary);
+		color: var(--primary);
+	}
+	.insert-form {
+		padding: 0.5rem;
+		border: 1px dashed var(--primary);
+		border-radius: 4px;
+		background: rgba(79, 195, 247, 0.05);
+	}
+	.insert-header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 0.35rem;
+	}
+	.insert-header select {
+		font-size: 0.75rem;
+		padding: 0.2rem 0.3rem;
+	}
+	.insert-textarea {
+		width: 100%;
+		resize: vertical;
+		font-family: inherit;
+		font-size: 0.85rem;
+	}
+
+	/* Loading */
+	.loading {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
+	.spinner {
+		display: inline-block;
+		width: 16px;
+		height: 16px;
+		border: 2px solid var(--border);
+		border-top-color: var(--primary);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	/* Error bar */
+	.error-bar {
+		background: rgba(239, 83, 80, 0.1);
+		border: 1px solid var(--danger);
+		color: var(--danger);
+		padding: 0.4rem 0.75rem;
+		border-radius: 4px;
+		font-size: 0.8rem;
+		margin-top: 0.25rem;
+	}
+
+	/* Input area */
+	.input-area {
+		display: flex;
+		gap: 0.5rem;
+		padding-top: 0.5rem;
+		border-top: 1px solid var(--border);
+		margin-top: 0.25rem;
+		align-items: flex-end;
+	}
+	.message-input {
+		flex: 1;
+		resize: none;
+		font-family: inherit;
+		font-size: 0.875rem;
+	}
+	.send-btn {
+		align-self: flex-end;
+		white-space: nowrap;
+	}
+
+	/* Viz panel */
+	.viz-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-height: 0;
+		overflow-y: auto;
+	}
+	.viz-section {
+		padding: 0.75rem;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--surface);
+	}
+	.heatmap-scroll {
+		overflow-y: auto;
+		max-height: 50%;
+		flex-shrink: 1;
+	}
+	.viz-title {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin-bottom: 0.5rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+	.viz-placeholder {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 3rem 1rem;
+		font-size: 0.9rem;
 	}
 </style>


### PR DESCRIPTION
## Summary

- Add `POST /api/generate` backend endpoint that uses `ProbingModel.generate()` to produce assistant responses (returns canned text in mock mode), with configurable temperature and max tokens
- Add `GenerateRequest`/`GenerateResponse` Pydantic models and `generate()` API client function
- Implement full interactive chat page with split layout: conversation panel (left) and visualization panel (right) showing `TokenHeatmap` + `TrajectoryChart`
- Support conversation editing: inline edit any message, delete messages, insert messages at arbitrary positions with role selection
- Add collapsible system prompt textarea, temperature slider (0-1.5), and max tokens slider (64-2048)
- Projections automatically recompute after generation, edits, deletions, and insertions

## Test plan

- [ ] Send a message and verify assistant response is generated and displayed
- [ ] Verify TokenHeatmap and TrajectoryChart render after first response
- [ ] Edit a message inline and confirm projections update
- [ ] Delete a message and confirm projections update
- [ ] Insert a message between existing messages and confirm projections update
- [ ] Toggle system prompt, set content, send message -- verify system prompt is included
- [ ] Adjust temperature and max tokens sliders, verify they affect generation
- [ ] Verify loading spinner shows during generation and projection stages
- [ ] Verify error messages display on API failure
- [ ] Clear all messages and verify UI resets
- [ ] Run `npm run build && npm run check` with zero errors

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)