### PR TITLE
axis-viewer: Save & load conversations to disk (#17)

### DIFF
--- a/axis-viewer/backend/app.py
+++ b/axis-viewer/backend/app.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from huggingface_hub import hf_hub_download
 
 from backend.config import AxisViewerConfig, load_config
+from backend.routes.conversations import router as conversations_router
 from backend.routes.generate import router as generate_router
 from backend.routes.project import router as project_router
 
@@ -98,6 +99,7 @@ def create_app(config_path: str = "config.yaml") -> FastAPI:
             "total_layers": config.total_layers,
         }
 
+    app.include_router(conversations_router)
     app.include_router(generate_router)
     app.include_router(project_router)
 

--- a/axis-viewer/backend/models.py
+++ b/axis-viewer/backend/models.py
@@ -44,3 +44,35 @@ class GenerateRequest(BaseModel):
 
 class GenerateResponse(BaseModel):
     content: str
+
+
+# --- Conversation save/load schemas ---
+
+
+class ConversationSave(BaseModel):
+    name: str
+    mode: str  # "chat" or "raw"
+    conversation: list[dict] | None = None  # for chat mode
+    text: str | None = None  # for raw mode
+    system_prompt: str | None = None  # optional system prompt for chat mode
+    metadata: dict | None = None
+
+
+class ConversationSummary(BaseModel):
+    id: str
+    name: str
+    mode: str
+    created_at: str
+    turn_count: int | None = None  # for chat mode
+    char_count: int | None = None  # for raw mode
+
+
+class ConversationDetail(BaseModel):
+    id: str
+    name: str
+    mode: str
+    conversation: list[dict] | None = None
+    text: str | None = None
+    system_prompt: str | None = None
+    metadata: dict | None = None
+    created_at: str

--- a/axis-viewer/backend/routes/conversations.py
+++ b/axis-viewer/backend/routes/conversations.py
@@ -1,0 +1,184 @@
+"""CRUD endpoints for saving and loading conversations."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from backend.models import ConversationDetail, ConversationSave, ConversationSummary
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/conversations", tags=["conversations"])
+
+
+def _conversations_dir(request: Request) -> Path:
+    """Return the conversations storage directory, creating it if needed."""
+    data_dir = Path(request.app.state.config.data_dir)
+    conv_dir = data_dir / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    return conv_dir
+
+
+def _read_conversation(path: Path) -> dict:
+    """Read and parse a single conversation JSON file."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def _detail_from_data(data: dict) -> ConversationDetail:
+    """Build a ConversationDetail from raw dict data."""
+    return ConversationDetail(
+        id=data["id"],
+        name=data["name"],
+        mode=data["mode"],
+        conversation=data.get("conversation"),
+        text=data.get("text"),
+        system_prompt=data.get("system_prompt"),
+        metadata=data.get("metadata"),
+        created_at=data.get("metadata", {}).get(
+            "created_at", data.get("created_at", "")
+        ),
+    )
+
+
+def _summary_from_data(data: dict) -> ConversationSummary:
+    """Build a ConversationSummary from raw dict data."""
+    created_at = data.get("metadata", {}).get(
+        "created_at", data.get("created_at", "")
+    )
+    turn_count = None
+    char_count = None
+    if data.get("mode") == "chat" and data.get("conversation"):
+        turn_count = len(data["conversation"])
+    elif data.get("mode") == "raw" and data.get("text"):
+        char_count = len(data["text"])
+
+    return ConversationSummary(
+        id=data["id"],
+        name=data["name"],
+        mode=data["mode"],
+        created_at=created_at,
+        turn_count=turn_count,
+        char_count=char_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=ConversationDetail, status_code=201)
+async def save_conversation(body: ConversationSave, request: Request):
+    """Save a new conversation to disk."""
+    conv_dir = _conversations_dir(request)
+    conv_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    metadata = body.metadata or {}
+    metadata.setdefault("created_at", now)
+    metadata.setdefault("updated_at", now)
+
+    data = {
+        "id": conv_id,
+        "name": body.name,
+        "mode": body.mode,
+        "metadata": metadata,
+    }
+
+    if body.mode == "chat":
+        data["conversation"] = body.conversation or []
+        if body.system_prompt is not None:
+            data["system_prompt"] = body.system_prompt
+    elif body.mode == "raw":
+        data["text"] = body.text or ""
+    else:
+        raise HTTPException(status_code=400, detail=f"Unknown mode: {body.mode}")
+
+    path = conv_dir / f"{conv_id}.json"
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+    logger.info("Saved conversation %s (%s) to %s", conv_id, body.name, path)
+    return _detail_from_data(data)
+
+
+@router.get("", response_model=list[ConversationSummary])
+async def list_conversations(request: Request):
+    """List all saved conversations, sorted by created_at descending."""
+    conv_dir = _conversations_dir(request)
+    summaries: list[ConversationSummary] = []
+
+    for path in conv_dir.glob("*.json"):
+        try:
+            data = _read_conversation(path)
+            summaries.append(_summary_from_data(data))
+        except (json.JSONDecodeError, KeyError) as exc:
+            logger.warning("Skipping invalid conversation file %s: %s", path, exc)
+            continue
+
+    # Sort by created_at descending (most recent first)
+    summaries.sort(key=lambda s: s.created_at, reverse=True)
+    return summaries
+
+
+@router.get("/export")
+async def export_conversations(request: Request):
+    """Export all conversations as a JSONL file download."""
+    conv_dir = _conversations_dir(request)
+
+    def generate_lines():
+        for path in sorted(conv_dir.glob("*.json")):
+            try:
+                data = _read_conversation(path)
+                yield json.dumps(data) + "\n"
+            except (json.JSONDecodeError, KeyError) as exc:
+                logger.warning("Skipping %s during export: %s", path, exc)
+                continue
+
+    return StreamingResponse(
+        generate_lines(),
+        media_type="application/x-ndjson",
+        headers={
+            "Content-Disposition": "attachment; filename=conversations.jsonl"
+        },
+    )
+
+
+@router.get("/{conversation_id}", response_model=ConversationDetail)
+async def get_conversation(conversation_id: str, request: Request):
+    """Load a single saved conversation."""
+    conv_dir = _conversations_dir(request)
+    path = conv_dir / f"{conversation_id}.json"
+
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    try:
+        data = _read_conversation(path)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Invalid conversation file: {exc}"
+        )
+
+    return _detail_from_data(data)
+
+
+@router.delete("/{conversation_id}", status_code=204)
+async def delete_conversation(conversation_id: str, request: Request):
+    """Delete a saved conversation."""
+    conv_dir = _conversations_dir(request)
+    path = conv_dir / f"{conversation_id}.json"
+
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    path.unlink()
+    logger.info("Deleted conversation %s", conversation_id)

--- a/axis-viewer/frontend/src/lib/api.ts
+++ b/axis-viewer/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@
  * API client for the axis-viewer backend.
  */
 
-import type { ProjectionResponse } from './types';
+import type { ProjectionResponse, ConversationSummary, ConversationDetail } from './types';
 
 const BASE = '/api';
 
@@ -51,4 +51,40 @@ export async function generate(
 			max_new_tokens: maxNewTokens
 		})
 	});
+}
+
+// --- Conversation save/load ---
+
+export async function saveConversation(data: {
+	name: string;
+	mode: string;
+	conversation?: Array<{ role: string; content: string }>;
+	text?: string;
+	system_prompt?: string;
+	metadata?: Record<string, unknown>;
+}): Promise<ConversationDetail> {
+	return request<ConversationDetail>('/conversations', {
+		method: 'POST',
+		body: JSON.stringify(data)
+	});
+}
+
+export async function listConversations(): Promise<ConversationSummary[]> {
+	return request<ConversationSummary[]>('/conversations');
+}
+
+export async function loadConversation(id: string): Promise<ConversationDetail> {
+	return request<ConversationDetail>(`/conversations/${id}`);
+}
+
+export async function deleteConversation(id: string): Promise<void> {
+	const res = await fetch(`${BASE}/conversations/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`${res.status}: ${body}`);
+	}
+}
+
+export function exportConversationsUrl(): string {
+	return `${BASE}/conversations/export`;
 }

--- a/axis-viewer/frontend/src/lib/components/SaveLoadPanel.svelte
+++ b/axis-viewer/frontend/src/lib/components/SaveLoadPanel.svelte
@@ -1,0 +1,395 @@
+<script lang="ts">
+	import {
+		listConversations,
+		saveConversation,
+		loadConversation,
+		deleteConversation,
+		exportConversationsUrl
+	} from '$lib/api';
+	import type { ConversationSummary, ConversationDetail } from '$lib/types';
+
+	interface Props {
+		mode: 'chat' | 'raw';
+		getSaveData: () => {
+			conversation?: Array<{ role: string; content: string }>;
+			text?: string;
+			system_prompt?: string;
+		};
+		onLoad: (detail: ConversationDetail) => void;
+		defaultName?: string;
+	}
+
+	let { mode, getSaveData, onLoad, defaultName = '' }: Props = $props();
+
+	let panelOpen = $state(false);
+	let conversations = $state<ConversationSummary[]>([]);
+	let loadingList = $state(false);
+	let listError = $state('');
+
+	// Save state
+	let saveName = $state('');
+	let saving = $state(false);
+	let saveSuccess = $state('');
+	let saveError = $state('');
+
+	// Delete confirmation
+	let deletingId = $state<string | null>(null);
+
+	async function fetchList() {
+		loadingList = true;
+		listError = '';
+		try {
+			const all = await listConversations();
+			conversations = all.filter((c) => c.mode === mode);
+		} catch (e) {
+			listError = e instanceof Error ? e.message : String(e);
+		} finally {
+			loadingList = false;
+		}
+	}
+
+	function togglePanel() {
+		panelOpen = !panelOpen;
+		if (panelOpen) {
+			fetchList();
+		}
+	}
+
+	async function handleSave() {
+		const name = saveName.trim();
+		if (!name) return;
+
+		saving = true;
+		saveError = '';
+		saveSuccess = '';
+		try {
+			const data = getSaveData();
+			const result = await saveConversation({
+				name,
+				mode,
+				...data
+			});
+			saveSuccess = `Saved as "${result.name}"`;
+			saveName = '';
+			// Refresh list
+			await fetchList();
+		} catch (e) {
+			saveError = e instanceof Error ? e.message : String(e);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleLoad(id: string) {
+		try {
+			const detail = await loadConversation(id);
+			onLoad(detail);
+			panelOpen = false;
+		} catch (e) {
+			listError = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	async function handleDelete(id: string) {
+		try {
+			await deleteConversation(id);
+			conversations = conversations.filter((c) => c.id !== id);
+			deletingId = null;
+		} catch (e) {
+			listError = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	function formatDate(iso: string): string {
+		if (!iso) return '';
+		try {
+			const d = new Date(iso);
+			return d.toLocaleDateString(undefined, {
+				month: 'short',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit'
+			});
+		} catch {
+			return iso;
+		}
+	}
+
+	// Update default name when prop changes
+	$effect(() => {
+		if (defaultName && !saveName) {
+			saveName = defaultName;
+		}
+	});
+</script>
+
+<div class="save-load-panel">
+	<button class="toggle-btn" onclick={togglePanel}>
+		<span class="toggle-arrow" class:open={panelOpen}>&#9654;</span>
+		Save / Load
+	</button>
+
+	{#if panelOpen}
+		<div class="panel-content">
+			<!-- Save section -->
+			<div class="save-section">
+				<div class="save-row">
+					<input
+						type="text"
+						class="save-name-input"
+						placeholder="Conversation name..."
+						bind:value={saveName}
+						onkeydown={(e) => {
+							if (e.key === 'Enter') handleSave();
+						}}
+					/>
+					<button class="primary save-btn" onclick={handleSave} disabled={saving || !saveName.trim()}>
+						{saving ? 'Saving...' : 'Save'}
+					</button>
+				</div>
+				{#if saveSuccess}
+					<div class="save-feedback success">{saveSuccess}</div>
+				{/if}
+				{#if saveError}
+					<div class="save-feedback error">{saveError}</div>
+				{/if}
+			</div>
+
+			<!-- Divider -->
+			<hr class="divider" />
+
+			<!-- List section -->
+			<div class="list-section">
+				<div class="list-header">
+					<span class="list-title">Saved ({conversations.length})</span>
+					<a href={exportConversationsUrl()} download class="export-link" title="Export all as JSONL">
+						Export JSONL
+					</a>
+				</div>
+
+				{#if loadingList}
+					<p class="list-status">Loading...</p>
+				{:else if listError}
+					<p class="list-status error">{listError}</p>
+				{:else if conversations.length === 0}
+					<p class="list-status">No saved {mode === 'chat' ? 'conversations' : 'texts'} yet.</p>
+				{:else}
+					<ul class="conversation-list">
+						{#each conversations as conv (conv.id)}
+							<li class="conversation-item">
+								{#if deletingId === conv.id}
+									<div class="delete-confirm">
+										<span>Delete "{conv.name}"?</span>
+										<button class="small danger" onclick={() => handleDelete(conv.id)}>
+											Yes
+										</button>
+										<button class="small" onclick={() => (deletingId = null)}>No</button>
+									</div>
+								{:else}
+									<button class="conv-load-btn" onclick={() => handleLoad(conv.id)}>
+										<span class="conv-name">{conv.name}</span>
+										<span class="conv-meta">
+											{formatDate(conv.created_at)}
+											{#if conv.turn_count != null}
+												&middot; {conv.turn_count} turns
+											{/if}
+											{#if conv.char_count != null}
+												&middot; {conv.char_count.toLocaleString()} chars
+											{/if}
+										</span>
+									</button>
+									<button
+										class="icon-btn danger-text"
+										title="Delete"
+										onclick={() => (deletingId = conv.id)}
+									>
+										&times;
+									</button>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.save-load-panel {
+		margin-bottom: 0.5rem;
+	}
+
+	.toggle-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		padding: 0.25rem 0;
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+	.toggle-btn:hover {
+		color: var(--text);
+		background: none;
+	}
+	.toggle-arrow {
+		display: inline-block;
+		font-size: 0.6rem;
+		transition: transform 0.15s;
+	}
+	.toggle-arrow.open {
+		transform: rotate(90deg);
+	}
+
+	.panel-content {
+		margin-top: 0.4rem;
+		padding: 0.75rem;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--surface);
+	}
+
+	/* Save section */
+	.save-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+	.save-row {
+		display: flex;
+		gap: 0.5rem;
+	}
+	.save-name-input {
+		flex: 1;
+		font-size: 0.8rem;
+		padding: 0.35rem 0.5rem;
+	}
+	.save-btn {
+		padding: 0.35rem 0.75rem;
+		font-size: 0.8rem;
+		white-space: nowrap;
+	}
+	.save-feedback {
+		font-size: 0.75rem;
+	}
+	.save-feedback.success {
+		color: var(--success);
+	}
+	.save-feedback.error {
+		color: var(--danger);
+	}
+
+	/* Divider */
+	.divider {
+		border: none;
+		border-top: 1px solid var(--border);
+		margin: 0.6rem 0;
+	}
+
+	/* List section */
+	.list-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.4rem;
+	}
+	.list-title {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
+	}
+	.export-link {
+		font-size: 0.7rem;
+		color: var(--primary);
+		text-decoration: none;
+	}
+	.export-link:hover {
+		text-decoration: underline;
+	}
+
+	.list-status {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		padding: 0.5rem 0;
+	}
+	.list-status.error {
+		color: var(--danger);
+	}
+
+	.conversation-list {
+		list-style: none;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		max-height: 200px;
+		overflow-y: auto;
+	}
+
+	.conversation-item {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.conv-load-btn {
+		flex: 1;
+		background: none;
+		border: 1px solid transparent;
+		text-align: left;
+		padding: 0.35rem 0.5rem;
+		border-radius: 4px;
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+		cursor: pointer;
+	}
+	.conv-load-btn:hover {
+		background: var(--surface-hover);
+		border-color: var(--border);
+	}
+
+	.conv-name {
+		font-size: 0.8rem;
+		color: var(--text);
+	}
+	.conv-meta {
+		font-size: 0.7rem;
+		color: var(--text-muted);
+	}
+
+	.icon-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1rem;
+		padding: 0.1rem 0.3rem;
+		line-height: 1;
+		cursor: pointer;
+		border-radius: 3px;
+	}
+	.icon-btn:hover {
+		background: var(--surface-hover);
+		color: var(--text);
+	}
+	.icon-btn.danger-text:hover {
+		color: var(--danger);
+	}
+
+	.delete-confirm {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.8rem;
+		padding: 0.25rem 0;
+		color: var(--text-muted);
+	}
+
+	button.small {
+		padding: 0.2rem 0.5rem;
+		font-size: 0.7rem;
+	}
+</style>

--- a/axis-viewer/frontend/src/lib/types.ts
+++ b/axis-viewer/frontend/src/lib/types.ts
@@ -26,3 +26,23 @@ export interface ProjectionResponse {
 	layer: number;
 	model_name: string;
 }
+
+export interface ConversationSummary {
+	id: string;
+	name: string;
+	mode: string;
+	created_at: string;
+	turn_count?: number;
+	char_count?: number;
+}
+
+export interface ConversationDetail {
+	id: string;
+	name: string;
+	mode: string;
+	conversation?: Array<{ role: string; content: string }>;
+	text?: string;
+	system_prompt?: string;
+	metadata?: Record<string, unknown>;
+	created_at: string;
+}

--- a/axis-viewer/frontend/src/routes/chat/+page.svelte
+++ b/axis-viewer/frontend/src/routes/chat/+page.svelte
@@ -2,7 +2,8 @@
 	import { generate, projectChat } from '$lib/api';
 	import TokenHeatmap from '$lib/components/TokenHeatmap.svelte';
 	import TrajectoryChart from '$lib/components/TrajectoryChart.svelte';
-	import type { ProjectionResponse } from '$lib/types';
+	import SaveLoadPanel from '$lib/components/SaveLoadPanel.svelte';
+	import type { ProjectionResponse, ConversationDetail } from '$lib/types';
 
 	// ---- State ----
 
@@ -180,12 +181,66 @@
 		errorMessage = '';
 	}
 
+	// ---- Save / Load ----
+
+	function getSaveData() {
+		return {
+			conversation: buildConversation(),
+			system_prompt: systemPrompt.trim() || undefined
+		};
+	}
+
+	async function handleLoad(detail: ConversationDetail) {
+		// Extract system prompt and messages from the conversation array
+		const conv = detail.conversation || [];
+		const sys = detail.system_prompt || '';
+		const msgs: Message[] = [];
+
+		for (const entry of conv) {
+			if (entry.role === 'system') {
+				// Use the first system message as system prompt if not set via field
+				if (!sys) {
+					systemPrompt = entry.content;
+				}
+			} else {
+				msgs.push({
+					role: entry.role as 'user' | 'assistant',
+					content: entry.content
+				});
+			}
+		}
+
+		if (sys) {
+			systemPrompt = sys;
+			systemPromptOpen = true;
+		}
+
+		messages = msgs;
+		editingIndex = null;
+		insertAtIndex = null;
+		errorMessage = '';
+
+		await updateProjections();
+	}
+
+	let defaultSaveName = $derived(
+		messages.length > 0 ? messages[0].content.slice(0, 50) : ''
+	);
+
 	let busy = $derived(generating || projecting);
 </script>
 
 <div class="chat-layout">
 	<!-- Left panel: conversation -->
 	<div class="chat-panel">
+		<!-- Save / Load -->
+		<SaveLoadPanel
+			mode="chat"
+			{getSaveData}
+			onLoad={handleLoad}
+			defaultName={defaultSaveName}
+		/>
+
 		<!-- System prompt (collapsible) -->
 		<div class="system-prompt-section">
 			<button

--- a/axis-viewer/frontend/src/routes/raw/+page.svelte
+++ b/axis-viewer/frontend/src/routes/raw/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { projectRaw } from '$lib/api';
-	import type { ProjectionResponse } from '$lib/types';
+	import type { ProjectionResponse, ConversationDetail } from '$lib/types';
 	import TokenHeatmap from '$lib/components/TokenHeatmap.svelte';
+	import SaveLoadPanel from '$lib/components/SaveLoadPanel.svelte';
 
 	let text = $state('');
 	let loading = $state(false);
@@ -32,9 +33,34 @@
 			analyze();
 		}
 	}
+
+	// ---- Save / Load ----
+
+	function getSaveData() {
+		return { text };
+	}
+
+	async function handleLoad(detail: ConversationDetail) {
+		text = detail.text || '';
+		error = null;
+		result = null;
+		// Auto-analyze after loading
+		if (text.trim()) {
+			await analyze();
+		}
+	}
+
+	let defaultSaveName = $derived(text.slice(0, 50) || '');
 </script>
 
 <div class="raw-page">
+	<SaveLoadPanel
+		mode="raw"
+		{getSaveData}
+		onLoad={handleLoad}
+		defaultName={defaultSaveName}
+	/>
+
 	<section class="input-section">
 		<textarea
 			bind:value={text}


### PR DESCRIPTION
## Summary

- Add backend CRUD endpoints (`POST/GET/DELETE /api/conversations`, `GET /api/conversations/export`) for persisting conversations as individual JSON files in `data/conversations/`
- Add reusable `SaveLoadPanel` Svelte component with inline save form, filterable conversation list, delete with confirmation, and JSONL export link
- Integrate save/load into both Chat and Raw Text pages -- loading auto-populates state and re-runs projections

Closes #17

## Test plan

- [ ] Save a chat conversation with a name, verify JSON file created in `data/conversations/`
- [ ] List conversations and verify chat conversations appear with turn count
- [ ] Load a saved chat conversation, verify messages and system prompt restore and projections compute
- [ ] Save raw text, verify it appears in list with character count
- [ ] Load raw text, verify textarea populates and analysis runs
- [ ] Delete a conversation with confirmation dialog
- [ ] Export JSONL downloads a valid `.jsonl` file with all conversations
- [ ] Frontend builds and type-checks with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)