### PR TITLE
axis-viewer: Batch JSONL upload & comparison view (#18)

### DIFF
--- a/axis-viewer/backend/app.py
+++ b/axis-viewer/backend/app.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from huggingface_hub import hf_hub_download
 
 from backend.config import AxisViewerConfig, load_config
+from backend.routes.batch import router as batch_router
 from backend.routes.conversations import router as conversations_router
 from backend.routes.generate import router as generate_router
 from backend.routes.project import router as project_router
@@ -99,6 +100,7 @@ def create_app(config_path: str = "config.yaml") -> FastAPI:
             "total_layers": config.total_layers,
         }
 
+    app.include_router(batch_router)
     app.include_router(conversations_router)
     app.include_router(generate_router)
     app.include_router(project_router)

--- a/axis-viewer/backend/models.py
+++ b/axis-viewer/backend/models.py
@@ -76,3 +76,30 @@ class ConversationDetail(BaseModel):
     system_prompt: str | None = None
     metadata: dict | None = None
     created_at: str
+
+
+# --- Batch schemas ---
+
+
+class BatchUploadResponse(BaseModel):
+    batch_id: str
+    count: int
+    conversations: list[ConversationSummary]
+
+
+class BatchConversationSummary(BaseModel):
+    """Summary statistics computed from a projection result."""
+
+    mean_projection: float
+    min_projection: float
+    max_projection: float
+    drift_amount: float | None = None  # max - min of per-turn means (chat only)
+
+
+class BatchConversationResult(BaseModel):
+    id: str
+    name: str
+    mode: str
+    projection: ProjectionResponse | None = None
+    error: str | None = None
+    summary: BatchConversationSummary | None = None

--- a/axis-viewer/backend/routes/batch.py
+++ b/axis-viewer/backend/routes/batch.py
@@ -1,0 +1,252 @@
+"""Batch upload and projection endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request, UploadFile
+from sse_starlette.sse import EventSourceResponse
+
+from backend.models import (
+    BatchConversationResult,
+    BatchConversationSummary,
+    BatchUploadResponse,
+    ConversationSummary,
+    ProjectionResponse,
+)
+from backend.routes.project import (
+    _extract_chat,
+    _extract_raw,
+    _mock_chat_response,
+    _mock_raw_response,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/batch", tags=["batch"])
+
+
+def _conversations_dir(request: Request) -> Path:
+    """Return the conversations storage directory, creating it if needed."""
+    data_dir = Path(request.app.state.config.data_dir)
+    conv_dir = data_dir / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    return conv_dir
+
+
+def _compute_summary(
+    projection: ProjectionResponse, mode: str
+) -> BatchConversationSummary:
+    """Compute summary statistics from projection data."""
+    if not projection.tokens:
+        return BatchConversationSummary(
+            mean_projection=0.0,
+            min_projection=0.0,
+            max_projection=0.0,
+            drift_amount=None,
+        )
+
+    all_projs = [t.projection for t in projection.tokens]
+    mean_val = sum(all_projs) / len(all_projs)
+    min_val = min(all_projs)
+    max_val = max(all_projs)
+
+    drift = None
+    if mode == "chat" and projection.spans:
+        span_means = [s.mean_projection for s in projection.spans]
+        drift = max(span_means) - min(span_means)
+
+    return BatchConversationSummary(
+        mean_projection=mean_val,
+        min_projection=min_val,
+        max_projection=max_val,
+        drift_amount=drift,
+    )
+
+
+@router.post("/upload", response_model=BatchUploadResponse)
+async def upload_batch(file: UploadFile, request: Request):
+    """Upload a JSONL file containing multiple conversations.
+
+    Each line should be a JSON object with ``name``, ``mode``, and either
+    ``conversation`` (for chat) or ``text`` (for raw) fields.
+    """
+    conv_dir = _conversations_dir(request)
+    batch_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    content = await file.read()
+    lines = content.decode("utf-8").strip().splitlines()
+
+    summaries: list[ConversationSummary] = []
+    for line_num, line in enumerate(lines, start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid JSON on line {line_num}: {exc}",
+            )
+
+        name = obj.get("name", f"conversation-{line_num}")
+        mode = obj.get("mode", "chat")
+        if mode not in ("chat", "raw"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid mode '{mode}' on line {line_num}",
+            )
+
+        conv_id = str(uuid.uuid4())
+        metadata = obj.get("metadata", {})
+        metadata.setdefault("created_at", now)
+        metadata.setdefault("updated_at", now)
+        metadata["batch_id"] = batch_id
+
+        data: dict = {
+            "id": conv_id,
+            "name": name,
+            "mode": mode,
+            "metadata": metadata,
+        }
+
+        if mode == "chat":
+            data["conversation"] = obj.get("conversation", [])
+            if obj.get("system_prompt"):
+                data["system_prompt"] = obj["system_prompt"]
+        else:
+            data["text"] = obj.get("text", "")
+
+        path = conv_dir / f"{conv_id}.json"
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+        turn_count = None
+        char_count = None
+        if mode == "chat":
+            turn_count = len(data.get("conversation", []))
+        else:
+            char_count = len(data.get("text", ""))
+
+        summaries.append(
+            ConversationSummary(
+                id=conv_id,
+                name=name,
+                mode=mode,
+                created_at=metadata["created_at"],
+                turn_count=turn_count,
+                char_count=char_count,
+            )
+        )
+
+    logger.info(
+        "Batch %s uploaded: %d conversations from %s",
+        batch_id,
+        len(summaries),
+        file.filename,
+    )
+    return BatchUploadResponse(
+        batch_id=batch_id,
+        count=len(summaries),
+        conversations=summaries,
+    )
+
+
+@router.post("/{batch_id}/project")
+async def project_batch(batch_id: str, request: Request):
+    """Project all conversations in a batch, streaming progress via SSE.
+
+    Events:
+    - ``progress``: ``{"conversation_id", "index", "total"}`` as each starts
+    - ``result``: ``{"conversation_id", "result": BatchConversationResult}``
+    - ``done``: sent when all projections are complete
+    """
+    conv_dir = _conversations_dir(request)
+    config = request.app.state.config
+
+    # Collect conversations belonging to this batch
+    batch_convs: list[dict] = []
+    for path in conv_dir.glob("*.json"):
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            if data.get("metadata", {}).get("batch_id") == batch_id:
+                batch_convs.append(data)
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    if not batch_convs:
+        raise HTTPException(status_code=404, detail="Batch not found")
+
+    # Sort by name for consistent ordering
+    batch_convs.sort(key=lambda d: d.get("name", ""))
+    total = len(batch_convs)
+
+    async def event_generator():
+        for idx, conv_data in enumerate(batch_convs):
+            conv_id = conv_data["id"]
+            name = conv_data["name"]
+            mode = conv_data["mode"]
+
+            # Send progress event
+            yield {
+                "event": "progress",
+                "data": json.dumps(
+                    {"conversation_id": conv_id, "index": idx, "total": total}
+                ),
+            }
+
+            try:
+                if mode == "chat":
+                    conversation = conv_data.get("conversation", [])
+                    if config.mock_model:
+                        projection = _mock_chat_response(conversation)
+                    else:
+                        projection = await asyncio.to_thread(
+                            _extract_chat, request, conversation
+                        )
+                else:
+                    text = conv_data.get("text", "")
+                    if config.mock_model:
+                        projection = _mock_raw_response(text)
+                    else:
+                        projection = await asyncio.to_thread(
+                            _extract_raw, request, text
+                        )
+
+                summary = _compute_summary(projection, mode)
+                result = BatchConversationResult(
+                    id=conv_id,
+                    name=name,
+                    mode=mode,
+                    projection=projection,
+                    summary=summary,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "Error projecting conversation %s in batch %s",
+                    conv_id,
+                    batch_id,
+                )
+                result = BatchConversationResult(
+                    id=conv_id,
+                    name=name,
+                    mode=mode,
+                    error=str(exc),
+                )
+
+            yield {
+                "event": "result",
+                "data": result.model_dump_json(),
+            }
+
+        yield {"event": "done", "data": json.dumps({"status": "complete"})}
+
+    return EventSourceResponse(event_generator())

--- a/axis-viewer/backend/tests/test_batch.py
+++ b/axis-viewer/backend/tests/test_batch.py
@@ -1,0 +1,326 @@
+"""Tests for the /api/batch endpoints."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+@pytest.fixture()
+def mock_client(tmp_path):
+    """Create a test client with mock mode enabled, using a temp data_dir."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"mock_model: true\ndata_dir: {tmp_path / 'data'}\n")
+    app = create_app(config_path=str(config_path))
+    with TestClient(app) as client:
+        yield client
+
+
+def _make_jsonl(conversations: list[dict]) -> bytes:
+    """Build JSONL bytes from a list of conversation dicts."""
+    return "\n".join(json.dumps(c) for c in conversations).encode("utf-8")
+
+
+class TestBatchUpload:
+    """Test POST /api/batch/upload."""
+
+    def test_upload_chat_conversations(self, mock_client):
+        content = _make_jsonl([
+            {
+                "name": "conv-1",
+                "mode": "chat",
+                "conversation": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"},
+                ],
+            },
+            {
+                "name": "conv-2",
+                "mode": "chat",
+                "conversation": [
+                    {"role": "user", "content": "Test"},
+                ],
+            },
+        ])
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("test.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 2
+        assert len(data["conversations"]) == 2
+        assert data["batch_id"]
+        # Check conversation summaries
+        names = {c["name"] for c in data["conversations"]}
+        assert names == {"conv-1", "conv-2"}
+
+    def test_upload_raw_text(self, mock_client):
+        content = _make_jsonl([
+            {"name": "raw-1", "mode": "raw", "text": "Some raw text here"},
+        ])
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("test.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["conversations"][0]["mode"] == "raw"
+        assert data["conversations"][0]["char_count"] == len("Some raw text here")
+
+    def test_upload_mixed_modes(self, mock_client):
+        content = _make_jsonl([
+            {
+                "name": "chat-one",
+                "mode": "chat",
+                "conversation": [{"role": "user", "content": "Hi"}],
+            },
+            {
+                "name": "raw-one",
+                "mode": "raw",
+                "text": "Raw text",
+            },
+        ])
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("test.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 2
+        modes = {c["mode"] for c in data["conversations"]}
+        assert modes == {"chat", "raw"}
+
+    def test_upload_invalid_json(self, mock_client):
+        content = b"not valid json\n"
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("bad.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 400
+        assert "Invalid JSON" in resp.json()["detail"]
+
+    def test_upload_invalid_mode(self, mock_client):
+        content = _make_jsonl([
+            {"name": "bad", "mode": "invalid_mode", "text": "x"},
+        ])
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("test.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 400
+        assert "Invalid mode" in resp.json()["detail"]
+
+    def test_upload_empty_file(self, mock_client):
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("empty.jsonl", b"", "application/x-ndjson")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 0
+
+    def test_upload_default_name(self, mock_client):
+        """Lines without a name get a default name."""
+        content = _make_jsonl([
+            {"mode": "chat", "conversation": [{"role": "user", "content": "test"}]},
+        ])
+        resp = mock_client.post(
+            "/api/batch/upload",
+            files={"file": ("test.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["conversations"][0]["name"] == "conversation-1"
+
+
+class TestBatchProject:
+    """Test POST /api/batch/{batch_id}/project (SSE streaming)."""
+
+    def _upload(self, client, conversations: list[dict]) -> str:
+        """Helper: upload a batch and return the batch_id."""
+        content = _make_jsonl(conversations)
+        resp = client.post(
+            "/api/batch/upload",
+            files={"file": ("test.jsonl", content, "application/x-ndjson")},
+        )
+        assert resp.status_code == 200
+        return resp.json()["batch_id"]
+
+    def test_project_returns_sse_stream(self, mock_client):
+        batch_id = self._upload(mock_client, [
+            {
+                "name": "conv-a",
+                "mode": "chat",
+                "conversation": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi there"},
+                ],
+            },
+        ])
+        # Use stream=True to get raw SSE response
+        with mock_client.stream("POST", f"/api/batch/{batch_id}/project") as resp:
+            assert resp.status_code == 200
+            events = []
+            for line in resp.iter_lines():
+                line = line.strip()
+                if line.startswith("event:"):
+                    events.append({"event": line[len("event:"):].strip()})
+                elif line.startswith("data:") and events:
+                    events[-1]["data"] = json.loads(line[len("data:"):].strip())
+
+        # Should have progress, result, and done events
+        event_types = [e["event"] for e in events]
+        assert "progress" in event_types
+        assert "result" in event_types
+        assert "done" in event_types
+
+    def test_project_result_has_projection_data(self, mock_client):
+        batch_id = self._upload(mock_client, [
+            {
+                "name": "test-conv",
+                "mode": "chat",
+                "conversation": [
+                    {"role": "user", "content": "Hello world"},
+                    {"role": "assistant", "content": "Hi there"},
+                ],
+            },
+        ])
+        with mock_client.stream("POST", f"/api/batch/{batch_id}/project") as resp:
+            result_events = []
+            current_event = {}
+            for line in resp.iter_lines():
+                line = line.strip()
+                if line.startswith("event:"):
+                    current_event = {"event": line[len("event:"):].strip()}
+                elif line.startswith("data:") and current_event:
+                    current_event["data"] = json.loads(line[len("data:"):].strip())
+                    if current_event["event"] == "result":
+                        result_events.append(current_event)
+                    current_event = {}
+
+        assert len(result_events) == 1
+        result_data = result_events[0]["data"]
+        assert result_data["name"] == "test-conv"
+        assert result_data["projection"] is not None
+        assert result_data["projection"]["tokens"]
+        assert result_data["projection"]["spans"]
+        assert result_data["summary"] is not None
+        assert "mean_projection" in result_data["summary"]
+        assert "drift_amount" in result_data["summary"]
+
+    def test_project_raw_text(self, mock_client):
+        batch_id = self._upload(mock_client, [
+            {"name": "raw-conv", "mode": "raw", "text": "Hello world foo bar"},
+        ])
+        with mock_client.stream("POST", f"/api/batch/{batch_id}/project") as resp:
+            result_events = []
+            current_event = {}
+            for line in resp.iter_lines():
+                line = line.strip()
+                if line.startswith("event:"):
+                    current_event = {"event": line[len("event:"):].strip()}
+                elif line.startswith("data:") and current_event:
+                    current_event["data"] = json.loads(line[len("data:"):].strip())
+                    if current_event["event"] == "result":
+                        result_events.append(current_event)
+                    current_event = {}
+
+        assert len(result_events) == 1
+        result_data = result_events[0]["data"]
+        assert result_data["mode"] == "raw"
+        assert result_data["projection"]["spans"] == []
+        # Raw mode: no drift
+        assert result_data["summary"]["drift_amount"] is None
+
+    def test_project_multiple_conversations(self, mock_client):
+        batch_id = self._upload(mock_client, [
+            {
+                "name": f"conv-{i}",
+                "mode": "chat",
+                "conversation": [
+                    {"role": "user", "content": f"Message {i}"},
+                    {"role": "assistant", "content": f"Reply {i}"},
+                ],
+            }
+            for i in range(5)
+        ])
+        with mock_client.stream("POST", f"/api/batch/{batch_id}/project") as resp:
+            result_events = []
+            progress_events = []
+            current_event = {}
+            for line in resp.iter_lines():
+                line = line.strip()
+                if line.startswith("event:"):
+                    current_event = {"event": line[len("event:"):].strip()}
+                elif line.startswith("data:") and current_event:
+                    current_event["data"] = json.loads(line[len("data:"):].strip())
+                    if current_event["event"] == "result":
+                        result_events.append(current_event)
+                    elif current_event["event"] == "progress":
+                        progress_events.append(current_event)
+                    current_event = {}
+
+        assert len(result_events) == 5
+        assert len(progress_events) == 5
+        # All progress events should have total == 5
+        for pe in progress_events:
+            assert pe["data"]["total"] == 5
+
+    def test_project_nonexistent_batch(self, mock_client):
+        resp = mock_client.post("/api/batch/nonexistent-id/project")
+        assert resp.status_code == 404
+
+
+class TestBatchSchemas:
+    """Verify batch-related Pydantic schemas."""
+
+    def test_batch_upload_response(self):
+        from backend.models import BatchUploadResponse, ConversationSummary
+
+        resp = BatchUploadResponse(
+            batch_id="abc123",
+            count=1,
+            conversations=[
+                ConversationSummary(
+                    id="c1", name="test", mode="chat",
+                    created_at="2025-01-01", turn_count=2,
+                )
+            ],
+        )
+        assert resp.batch_id == "abc123"
+        assert resp.count == 1
+
+    def test_batch_conversation_result(self):
+        from backend.models import BatchConversationResult, BatchConversationSummary
+
+        result = BatchConversationResult(
+            id="c1",
+            name="test",
+            mode="chat",
+            summary=BatchConversationSummary(
+                mean_projection=0.5,
+                min_projection=-1.0,
+                max_projection=2.0,
+                drift_amount=1.5,
+            ),
+        )
+        assert result.summary is not None
+        assert result.summary.drift_amount == 1.5
+
+    def test_batch_conversation_result_with_error(self):
+        from backend.models import BatchConversationResult
+
+        result = BatchConversationResult(
+            id="c1",
+            name="test",
+            mode="chat",
+            error="Something went wrong",
+        )
+        assert result.error == "Something went wrong"
+        assert result.projection is None

--- a/axis-viewer/frontend/src/lib/api.ts
+++ b/axis-viewer/frontend/src/lib/api.ts
@@ -2,7 +2,12 @@
  * API client for the axis-viewer backend.
  */
 
-import type { ProjectionResponse, ConversationSummary, ConversationDetail } from './types';
+import type {
+	ProjectionResponse,
+	ConversationSummary,
+	ConversationDetail,
+	BatchUploadResponse
+} from './types';
 
 const BASE = '/api';
 
@@ -87,4 +92,24 @@ export async function deleteConversation(id: string): Promise<void> {
 
 export function exportConversationsUrl(): string {
 	return `${BASE}/conversations/export`;
+}
+
+// --- Batch endpoints ---
+
+export async function uploadBatch(file: File): Promise<BatchUploadResponse> {
+	const formData = new FormData();
+	formData.append('file', file);
+	const res = await fetch(`${BASE}/batch/upload`, {
+		method: 'POST',
+		body: formData
+	});
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`${res.status}: ${body}`);
+	}
+	return res.json() as Promise<BatchUploadResponse>;
+}
+
+export function batchProjectUrl(batchId: string): string {
+	return `${BASE}/batch/${batchId}/project`;
 }

--- a/axis-viewer/frontend/src/lib/components/ComparisonChart.svelte
+++ b/axis-viewer/frontend/src/lib/components/ComparisonChart.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+	import type { TurnSpan } from '$lib/types';
+	import Tooltip from './Tooltip.svelte';
+
+	interface TrajectoryData {
+		name: string;
+		spans: TurnSpan[];
+		color: string;
+	}
+
+	let { trajectories }: { trajectories: TrajectoryData[] } = $props();
+
+	// SVG dimensions
+	const width = 700;
+	const height = 350;
+	const padding = { top: 30, right: 140, bottom: 40, left: 60 };
+
+	// Tooltip state
+	let tooltipX = $state(0);
+	let tooltipY = $state(0);
+	let hoveredPoint = $state<{ trajectory: TrajectoryData; span: TurnSpan } | null>(null);
+
+	// Sorted spans per trajectory
+	let sortedTrajectories = $derived(
+		trajectories.map((t) => ({
+			...t,
+			sortedSpans: [...t.spans].sort((a, b) => a.turn - b.turn)
+		}))
+	);
+
+	// Global axis extents across all trajectories
+	let xExtent = $derived.by((): [number, number] => {
+		const allTurns = sortedTrajectories.flatMap((t) => t.sortedSpans.map((s) => s.turn));
+		if (allTurns.length === 0) return [0, 1];
+		return [Math.min(...allTurns), Math.max(...allTurns)];
+	});
+
+	let yExtent = $derived.by((): [number, number] => {
+		const allVals = sortedTrajectories.flatMap((t) =>
+			t.sortedSpans.map((s) => s.mean_projection)
+		);
+		if (allVals.length === 0) return [0, 1];
+		const min = Math.min(...allVals);
+		const max = Math.max(...allVals);
+		const range = max - min || 1;
+		return [min - range * 0.1, max + range * 0.1];
+	});
+
+	function scaleX(turn: number): number {
+		const [min, max] = xExtent;
+		const range = max - min || 1;
+		return padding.left + ((turn - min) / range) * (width - padding.left - padding.right);
+	}
+
+	function scaleY(val: number): number {
+		const [min, max] = yExtent;
+		const range = max - min || 1;
+		return (
+			height - padding.bottom - ((val - min) / range) * (height - padding.top - padding.bottom)
+		);
+	}
+
+	// Build line paths for each trajectory
+	function buildLinePath(spans: TurnSpan[]): string {
+		if (spans.length === 0) return '';
+		return spans
+			.map((s, i) => {
+				const x = scaleX(s.turn);
+				const y = scaleY(s.mean_projection);
+				return `${i === 0 ? 'M' : 'L'} ${x} ${y}`;
+			})
+			.join(' ');
+	}
+
+	// Y-axis ticks
+	let yTicks = $derived.by(() => {
+		const [min, max] = yExtent;
+		const step = (max - min) / 4;
+		return Array.from({ length: 5 }, (_, i) => min + i * step);
+	});
+
+	// X-axis ticks
+	let xTicks = $derived.by(() => {
+		const allTurns = sortedTrajectories.flatMap((t) => t.sortedSpans.map((s) => s.turn));
+		if (allTurns.length === 0) return [0];
+		const unique = [...new Set(allTurns)].sort((a, b) => a - b);
+		if (unique.length <= 12) return unique;
+		const [min, max] = xExtent;
+		const step = Math.max(1, Math.floor((max - min) / 8));
+		const ticks: number[] = [];
+		for (let t = min; t <= max; t += step) ticks.push(t);
+		if (ticks[ticks.length - 1] !== max) ticks.push(max);
+		return ticks;
+	});
+
+	function handleMouseMove(e: MouseEvent) {
+		tooltipX = e.clientX;
+		tooltipY = e.clientY;
+	}
+
+	function truncate(text: string, maxLen: number): string {
+		if (text.length <= maxLen) return text;
+		return text.slice(0, maxLen) + '...';
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="chart-container" onmousemove={handleMouseMove}>
+	{#if sortedTrajectories.every((t) => t.sortedSpans.length === 0)}
+		<p class="empty">No trajectory data to compare.</p>
+	{:else}
+		<svg viewBox="0 0 {width} {height}" class="chart-svg">
+			<!-- Y-axis grid lines and labels -->
+			{#each yTicks as tick}
+				<line
+					x1={padding.left}
+					y1={scaleY(tick)}
+					x2={width - padding.right}
+					y2={scaleY(tick)}
+					class="grid-line"
+				/>
+				<text x={padding.left - 8} y={scaleY(tick) + 4} class="axis-tick" text-anchor="end"
+					>{tick.toFixed(3)}</text
+				>
+			{/each}
+
+			<!-- X-axis grid lines and labels -->
+			{#each xTicks as tick}
+				<line
+					x1={scaleX(tick)}
+					y1={padding.top}
+					x2={scaleX(tick)}
+					y2={height - padding.bottom}
+					class="grid-line"
+				/>
+				<text
+					x={scaleX(tick)}
+					y={height - padding.bottom + 16}
+					class="axis-tick"
+					text-anchor="middle">{tick}</text
+				>
+			{/each}
+
+			<!-- Axes -->
+			<line
+				x1={padding.left}
+				y1={height - padding.bottom}
+				x2={width - padding.right}
+				y2={height - padding.bottom}
+				class="axis"
+			/>
+			<line
+				x1={padding.left}
+				y1={padding.top}
+				x2={padding.left}
+				y2={height - padding.bottom}
+				class="axis"
+			/>
+
+			<!-- Baseline reference -->
+			{#if yExtent[0] <= 0 && yExtent[1] >= 0}
+				<line
+					x1={padding.left}
+					y1={scaleY(0)}
+					x2={width - padding.right}
+					y2={scaleY(0)}
+					class="reference-line"
+				/>
+				<text x={width - padding.right + 4} y={scaleY(0) + 4} class="reference-label"
+					>baseline</text
+				>
+			{/if}
+
+			<!-- Trajectory lines and points -->
+			{#each sortedTrajectories as traj}
+				<path d={buildLinePath(traj.sortedSpans)} fill="none" stroke={traj.color} stroke-width="2" opacity="0.7" />
+				{#each traj.sortedSpans as span}
+					<circle
+						cx={scaleX(span.turn)}
+						cy={scaleY(span.mean_projection)}
+						r={hoveredPoint?.trajectory === traj && hoveredPoint?.span === span ? 7 : 5}
+						fill={traj.color}
+						class="point"
+						class:hovered={hoveredPoint?.trajectory === traj && hoveredPoint?.span === span}
+						onmouseenter={() => {
+							hoveredPoint = { trajectory: traj, span };
+						}}
+						onmouseleave={() => {
+							hoveredPoint = null;
+						}}
+						role="button"
+						tabindex="0"
+					/>
+				{/each}
+			{/each}
+
+			<!-- Axis labels -->
+			<text
+				x={(padding.left + width - padding.right) / 2}
+				y={height - 4}
+				class="axis-label">Turn</text
+			>
+			<text
+				x={14}
+				y={(padding.top + height - padding.bottom) / 2}
+				class="axis-label"
+				transform="rotate(-90, 14, {(padding.top + height - padding.bottom) / 2})"
+				>Mean Projection</text
+			>
+		</svg>
+
+		<!-- Legend -->
+		<div class="legend">
+			{#each sortedTrajectories as traj}
+				<span class="legend-item">
+					<span class="legend-dot" style="background: {traj.color};"></span>
+					{truncate(traj.name, 30)}
+				</span>
+			{/each}
+		</div>
+	{/if}
+
+	<Tooltip x={tooltipX} y={tooltipY} visible={hoveredPoint !== null}>
+		{#if hoveredPoint}
+			<div class="tip-name">
+				<strong>{truncate(hoveredPoint.trajectory.name, 40)}</strong>
+			</div>
+			<div class="tip-detail">
+				Turn {hoveredPoint.span.turn} ({hoveredPoint.span.role})
+			</div>
+			<div class="tip-detail">
+				mean projection: {hoveredPoint.span.mean_projection.toFixed(4)}
+			</div>
+			<div class="tip-text">{truncate(hoveredPoint.span.text, 80)}</div>
+		{/if}
+	</Tooltip>
+</div>
+
+<style>
+	.chart-container {
+		position: relative;
+		width: 100%;
+	}
+	.chart-svg {
+		width: 100%;
+		max-width: 800px;
+		display: block;
+	}
+	.empty {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 2rem;
+	}
+	.grid-line {
+		stroke: var(--border);
+		stroke-width: 0.5;
+		opacity: 0.4;
+	}
+	.axis {
+		stroke: var(--text-muted);
+		stroke-width: 1;
+	}
+	.axis-tick {
+		fill: var(--text-muted);
+		font-size: 9px;
+		font-family: monospace;
+	}
+	.axis-label {
+		fill: var(--text-muted);
+		font-size: 11px;
+		text-anchor: middle;
+	}
+	.reference-line {
+		stroke: var(--text-muted);
+		stroke-width: 1;
+		stroke-dasharray: 6 3;
+		opacity: 0.5;
+	}
+	.reference-label {
+		fill: var(--text-muted);
+		font-size: 9px;
+		font-style: italic;
+	}
+	.point {
+		cursor: pointer;
+		stroke: var(--bg);
+		stroke-width: 2;
+		transition:
+			r 0.15s,
+			stroke-width 0.15s;
+		opacity: 0.9;
+	}
+	.point:hover,
+	.point.hovered {
+		opacity: 1;
+		stroke: var(--text);
+		stroke-width: 2.5;
+	}
+	.legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1rem;
+		margin-top: 0.5rem;
+		padding: 0.25rem 0;
+	}
+	.legend-item {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+	.legend-dot {
+		display: inline-block;
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+	.tip-name {
+		margin-bottom: 0.25rem;
+	}
+	.tip-detail {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		font-family: monospace;
+		margin-bottom: 0.1rem;
+	}
+	.tip-text {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		line-height: 1.3;
+	}
+</style>

--- a/axis-viewer/frontend/src/lib/types.ts
+++ b/axis-viewer/frontend/src/lib/types.ts
@@ -46,3 +46,27 @@ export interface ConversationDetail {
 	metadata?: Record<string, unknown>;
 	created_at: string;
 }
+
+// --- Batch types ---
+
+export interface BatchUploadResponse {
+	batch_id: string;
+	count: number;
+	conversations: ConversationSummary[];
+}
+
+export interface BatchConversationSummary {
+	mean_projection: number;
+	min_projection: number;
+	max_projection: number;
+	drift_amount: number | null;
+}
+
+export interface BatchConversationResult {
+	id: string;
+	name: string;
+	mode: string;
+	projection?: ProjectionResponse;
+	error?: string;
+	summary?: BatchConversationSummary;
+}

--- a/axis-viewer/frontend/src/routes/batch/+page.svelte
+++ b/axis-viewer/frontend/src/routes/batch/+page.svelte
@@ -1,9 +1,767 @@
-<p class="placeholder">Batch mode coming soon</p>
+<script lang="ts">
+	import { uploadBatch, batchProjectUrl } from '$lib/api';
+	import type {
+		BatchUploadResponse,
+		BatchConversationResult,
+		TurnSpan,
+		ProjectionResponse
+	} from '$lib/types';
+	import TokenHeatmap from '$lib/components/TokenHeatmap.svelte';
+	import TrajectoryChart from '$lib/components/TrajectoryChart.svelte';
+	import ComparisonChart from '$lib/components/ComparisonChart.svelte';
+
+	// --- Upload state ---
+	let selectedFile = $state<File | null>(null);
+	let lineCount = $state(0);
+	let uploading = $state(false);
+	let uploadError = $state('');
+	let dragOver = $state(false);
+
+	// --- Batch state ---
+	let batchResponse = $state<BatchUploadResponse | null>(null);
+	let results = $state<BatchConversationResult[]>([]);
+	let projecting = $state(false);
+	let projectProgress = $state({ index: 0, total: 0 });
+
+	// --- UI state ---
+	let expandedId = $state<string | null>(null);
+	let selectedIds = $state<Set<string>>(new Set());
+	let showComparison = $state(false);
+	let sortColumn = $state<string>('name');
+	let sortDir = $state<'asc' | 'desc'>('asc');
+
+	// --- Filters ---
+	let filterMode = $state<string>('all');
+	let filterSearch = $state('');
+	let filterDriftMin = $state(0);
+
+	// Palette for comparison
+	const COLORS = [
+		'#4fc3f7',
+		'#ffa726',
+		'#66bb6a',
+		'#ef5350',
+		'#ab47bc',
+		'#26c6da',
+		'#ffca28',
+		'#8d6e63',
+		'#ec407a',
+		'#7e57c2'
+	];
+
+	// --- File handling ---
+	function countLines(text: string): number {
+		return text
+			.trim()
+			.split('\n')
+			.filter((l) => l.trim()).length;
+	}
+
+	async function handleFileSelect(file: File) {
+		selectedFile = file;
+		uploadError = '';
+		const text = await file.text();
+		lineCount = countLines(text);
+	}
+
+	function handleDrop(e: DragEvent) {
+		e.preventDefault();
+		dragOver = false;
+		const file = e.dataTransfer?.files[0];
+		if (file && (file.name.endsWith('.jsonl') || file.name.endsWith('.ndjson'))) {
+			handleFileSelect(file);
+		} else {
+			uploadError = 'Please drop a .jsonl or .ndjson file.';
+		}
+	}
+
+	function handleDragOver(e: DragEvent) {
+		e.preventDefault();
+		dragOver = true;
+	}
+
+	function handleDragLeave() {
+		dragOver = false;
+	}
+
+	function handleInputChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const file = target.files?.[0];
+		if (file) handleFileSelect(file);
+	}
+
+	// --- Upload & project ---
+	async function doUploadAndProject() {
+		if (!selectedFile) return;
+		uploading = true;
+		uploadError = '';
+		results = [];
+		expandedId = null;
+		selectedIds = new Set();
+		showComparison = false;
+
+		try {
+			batchResponse = await uploadBatch(selectedFile);
+		} catch (err) {
+			uploadError = err instanceof Error ? err.message : String(err);
+			uploading = false;
+			return;
+		}
+
+		uploading = false;
+		projecting = true;
+		projectProgress = { index: 0, total: batchResponse.count };
+
+		// Stream projections via SSE
+		const url = batchProjectUrl(batchResponse.batch_id);
+		const eventSource = new EventSource(url);
+
+		eventSource.addEventListener('progress', (e: MessageEvent) => {
+			const data = JSON.parse(e.data);
+			projectProgress = { index: data.index, total: data.total };
+		});
+
+		eventSource.addEventListener('result', (e: MessageEvent) => {
+			const result: BatchConversationResult = JSON.parse(e.data);
+			results = [...results, result];
+		});
+
+		eventSource.addEventListener('done', () => {
+			eventSource.close();
+			projecting = false;
+		});
+
+		eventSource.onerror = () => {
+			eventSource.close();
+			projecting = false;
+			if (results.length === 0) {
+				uploadError = 'Connection lost during batch projection.';
+			}
+		};
+	}
+
+	// --- Sorting ---
+	function toggleSort(column: string) {
+		if (sortColumn === column) {
+			sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortColumn = column;
+			sortDir = 'asc';
+		}
+	}
+
+	function sortIndicator(column: string): string {
+		if (sortColumn !== column) return '';
+		return sortDir === 'asc' ? ' ^' : ' v';
+	}
+
+	// --- Filtered & sorted results ---
+	let filteredResults = $derived.by(() => {
+		let items = results;
+
+		// Mode filter
+		if (filterMode !== 'all') {
+			items = items.filter((r) => r.mode === filterMode);
+		}
+
+		// Search filter
+		if (filterSearch.trim()) {
+			const q = filterSearch.trim().toLowerCase();
+			items = items.filter((r) => r.name.toLowerCase().includes(q));
+		}
+
+		// Drift filter
+		if (filterDriftMin > 0) {
+			items = items.filter(
+				(r) => r.summary?.drift_amount != null && r.summary.drift_amount >= filterDriftMin
+			);
+		}
+
+		// Sort
+		const dir = sortDir === 'asc' ? 1 : -1;
+		items = [...items].sort((a, b) => {
+			switch (sortColumn) {
+				case 'name':
+					return dir * a.name.localeCompare(b.name);
+				case 'mode':
+					return dir * a.mode.localeCompare(b.mode);
+				case 'turns': {
+					const at = a.projection?.spans.length ?? 0;
+					const bt = b.projection?.spans.length ?? 0;
+					return dir * (at - bt);
+				}
+				case 'tokens': {
+					const at = a.projection?.tokens.length ?? 0;
+					const bt = b.projection?.tokens.length ?? 0;
+					return dir * (at - bt);
+				}
+				case 'mean': {
+					const am = a.summary?.mean_projection ?? 0;
+					const bm = b.summary?.mean_projection ?? 0;
+					return dir * (am - bm);
+				}
+				case 'min': {
+					const am = a.summary?.min_projection ?? 0;
+					const bm = b.summary?.min_projection ?? 0;
+					return dir * (am - bm);
+				}
+				case 'drift': {
+					const ad = a.summary?.drift_amount ?? -Infinity;
+					const bd = b.summary?.drift_amount ?? -Infinity;
+					return dir * (ad - bd);
+				}
+				default:
+					return 0;
+			}
+		});
+
+		return items;
+	});
+
+	// --- Selection ---
+	function toggleSelect(id: string) {
+		const next = new Set(selectedIds);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		selectedIds = next;
+	}
+
+	function toggleSelectAll() {
+		if (selectedIds.size === filteredResults.length) {
+			selectedIds = new Set();
+		} else {
+			selectedIds = new Set(filteredResults.map((r) => r.id));
+		}
+	}
+
+	// --- Comparison data ---
+	let comparisonTrajectories = $derived.by(() => {
+		return results
+			.filter((r) => selectedIds.has(r.id) && r.projection && r.projection.spans.length > 0)
+			.map((r, i) => ({
+				name: r.name,
+				spans: r.projection!.spans,
+				color: COLORS[i % COLORS.length]
+			}));
+	});
+
+	// --- Row expand ---
+	function toggleExpand(id: string) {
+		expandedId = expandedId === id ? null : id;
+	}
+</script>
+
+<div class="batch-page">
+	<h2>Batch Analysis</h2>
+
+	<!-- Upload section -->
+	{#if !batchResponse && !projecting}
+		<section class="upload-section">
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="drop-zone"
+				class:drag-over={dragOver}
+				ondrop={handleDrop}
+				ondragover={handleDragOver}
+				ondragleave={handleDragLeave}
+			>
+				{#if selectedFile}
+					<p class="file-info">
+						<strong>{selectedFile.name}</strong> - {lineCount} conversation{lineCount !== 1
+							? 's'
+							: ''}
+					</p>
+				{:else}
+					<p>Drop a .jsonl file here, or click to select</p>
+				{/if}
+				<input
+					type="file"
+					accept=".jsonl,.ndjson"
+					onchange={handleInputChange}
+					class="file-input"
+				/>
+			</div>
+
+			<div class="upload-actions">
+				<button
+					class="primary"
+					disabled={!selectedFile || uploading}
+					onclick={doUploadAndProject}
+				>
+					{uploading ? 'Uploading...' : 'Upload & Analyze'}
+				</button>
+			</div>
+
+			{#if uploadError}
+				<p class="error">{uploadError}</p>
+			{/if}
+		</section>
+	{/if}
+
+	<!-- Progress section -->
+	{#if projecting || uploading}
+		<section class="progress-section">
+			<h3>
+				{uploading
+					? 'Uploading...'
+					: `Processing ${projectProgress.index + 1} of ${projectProgress.total}...`}
+			</h3>
+			<div class="progress-bar-track">
+				<div
+					class="progress-bar-fill"
+					style="width: {projectProgress.total > 0
+						? (results.length / projectProgress.total) * 100
+						: 0}%"
+				></div>
+			</div>
+			<p class="progress-label">
+				{results.length} / {projectProgress.total} completed
+			</p>
+		</section>
+	{/if}
+
+	<!-- Results section -->
+	{#if results.length > 0}
+		<section class="results-section">
+			<!-- Filters -->
+			<div class="filters">
+				<input
+					type="text"
+					placeholder="Search by name..."
+					bind:value={filterSearch}
+					class="filter-input"
+				/>
+				<select bind:value={filterMode} class="filter-select">
+					<option value="all">All modes</option>
+					<option value="chat">Chat</option>
+					<option value="raw">Raw</option>
+				</select>
+				<label class="drift-filter">
+					Min drift:
+					<input
+						type="number"
+						step="0.1"
+						min="0"
+						bind:value={filterDriftMin}
+						class="drift-input"
+					/>
+				</label>
+				<button
+					class="reset-btn"
+					onclick={() => {
+						selectedFile = null;
+						batchResponse = null;
+						results = [];
+						expandedId = null;
+						selectedIds = new Set();
+						showComparison = false;
+						uploadError = '';
+					}}
+				>
+					New Batch
+				</button>
+			</div>
+
+			<!-- Selection actions -->
+			<div class="selection-actions">
+				<label class="select-all">
+					<input
+						type="checkbox"
+						checked={selectedIds.size === filteredResults.length &&
+							filteredResults.length > 0}
+						onchange={toggleSelectAll}
+					/>
+					Select all ({selectedIds.size} selected)
+				</label>
+				{#if selectedIds.size >= 2}
+					<button class="primary" onclick={() => (showComparison = !showComparison)}>
+						{showComparison ? 'Hide' : 'Compare'} ({selectedIds.size})
+					</button>
+				{/if}
+			</div>
+
+			<!-- Comparison overlay -->
+			{#if showComparison && comparisonTrajectories.length >= 2}
+				<div class="comparison-panel">
+					<h3>Trajectory Comparison</h3>
+					<ComparisonChart trajectories={comparisonTrajectories} />
+				</div>
+			{/if}
+
+			<!-- Results table -->
+			<div class="table-wrapper">
+				<table>
+					<thead>
+						<tr>
+							<th class="col-check"></th>
+							<th class="col-name sortable" onclick={() => toggleSort('name')}
+								>Name{sortIndicator('name')}</th
+							>
+							<th class="col-mode sortable" onclick={() => toggleSort('mode')}
+								>Mode{sortIndicator('mode')}</th
+							>
+							<th class="col-size sortable" onclick={() => toggleSort('turns')}
+								>Turns/Tokens{sortIndicator('turns')}</th
+							>
+							<th class="col-num sortable" onclick={() => toggleSort('mean')}
+								>Mean{sortIndicator('mean')}</th
+							>
+							<th class="col-num sortable" onclick={() => toggleSort('min')}
+								>Min{sortIndicator('min')}</th
+							>
+							<th class="col-num sortable" onclick={() => toggleSort('drift')}
+								>Drift{sortIndicator('drift')}</th
+							>
+							<th class="col-status">Status</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each filteredResults as result (result.id)}
+							<tr
+								class="result-row"
+								class:expanded={expandedId === result.id}
+								class:has-error={!!result.error}
+							>
+								<td>
+									<input
+										type="checkbox"
+										checked={selectedIds.has(result.id)}
+										onchange={() => toggleSelect(result.id)}
+									/>
+								</td>
+								<!-- svelte-ignore a11y_click_events_have_key_events -->
+								<td class="clickable" onclick={() => toggleExpand(result.id)} role="button" tabindex="0"
+									>{result.name}</td
+								>
+								<td>
+									<span class="mode-badge" class:chat={result.mode === 'chat'}
+										>{result.mode}</span
+									>
+								</td>
+								<td>
+									{#if result.mode === 'chat'}
+										{result.projection?.spans.length ?? '-'}
+									{:else}
+										{result.projection?.tokens.length ?? '-'}
+									{/if}
+								</td>
+								<td class="num">{result.summary?.mean_projection?.toFixed(4) ?? '-'}</td>
+								<td class="num">{result.summary?.min_projection?.toFixed(4) ?? '-'}</td>
+								<td class="num">
+									{result.summary?.drift_amount != null
+										? result.summary.drift_amount.toFixed(4)
+										: '-'}
+								</td>
+								<td>
+									{#if result.error}
+										<span class="status-error" title={result.error}>Error</span>
+									{:else}
+										<span class="status-ok">Done</span>
+									{/if}
+								</td>
+							</tr>
+							{#if expandedId === result.id && result.projection}
+								<tr class="expanded-row">
+									<td colspan="8">
+										<div class="expanded-content">
+											{#if result.projection.spans.length > 0}
+												<div class="expanded-chart">
+													<h4>Trajectory</h4>
+													<TrajectoryChart spans={result.projection.spans} />
+												</div>
+											{/if}
+											<div class="expanded-heatmap">
+												<h4>Token Heatmap</h4>
+												<TokenHeatmap response={result.projection} />
+											</div>
+										</div>
+									</td>
+								</tr>
+							{/if}
+						{/each}
+					</tbody>
+				</table>
+			</div>
+
+			{#if filteredResults.length === 0 && results.length > 0}
+				<p class="empty-filter">No results match your filters.</p>
+			{/if}
+		</section>
+	{/if}
+</div>
 
 <style>
-	.placeholder {
-		color: var(--text-muted);
+	.batch-page {
+		max-width: 1100px;
+	}
+
+	h2 {
+		font-size: 1.1rem;
+		margin-bottom: 1rem;
+	}
+
+	/* Upload section */
+	.upload-section {
+		margin-bottom: 1.5rem;
+	}
+
+	.drop-zone {
+		border: 2px dashed var(--border);
+		border-radius: 8px;
 		padding: 2rem;
 		text-align: center;
+		position: relative;
+		cursor: pointer;
+		transition:
+			border-color 0.2s,
+			background 0.2s;
+	}
+
+	.drop-zone:hover,
+	.drop-zone.drag-over {
+		border-color: var(--primary);
+		background: rgba(79, 195, 247, 0.05);
+	}
+
+	.drop-zone p {
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.file-info {
+		color: var(--text) !important;
+	}
+
+	.file-input {
+		position: absolute;
+		inset: 0;
+		opacity: 0;
+		cursor: pointer;
+	}
+
+	.upload-actions {
+		margin-top: 1rem;
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.error {
+		color: var(--danger);
+		margin-top: 0.5rem;
+		font-size: 0.85rem;
+	}
+
+	/* Progress section */
+	.progress-section {
+		margin-bottom: 1.5rem;
+	}
+
+	.progress-section h3 {
+		font-size: 0.95rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.progress-bar-track {
+		height: 8px;
+		background: var(--surface);
+		border-radius: 4px;
+		overflow: hidden;
+		border: 1px solid var(--border);
+	}
+
+	.progress-bar-fill {
+		height: 100%;
+		background: var(--primary);
+		transition: width 0.3s ease;
+		border-radius: 4px;
+	}
+
+	.progress-label {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		margin-top: 0.25rem;
+	}
+
+	/* Filters */
+	.filters {
+		display: flex;
+		gap: 0.75rem;
+		align-items: center;
+		margin-bottom: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.filter-input {
+		flex: 1;
+		min-width: 150px;
+		max-width: 250px;
+	}
+
+	.filter-select {
+		width: 120px;
+	}
+
+	.drift-filter {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+
+	.drift-input {
+		width: 70px;
+	}
+
+	.reset-btn {
+		margin-left: auto;
+	}
+
+	/* Selection */
+	.selection-actions {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 0.75rem;
+		font-size: 0.85rem;
+	}
+
+	.select-all {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		color: var(--text-muted);
+		cursor: pointer;
+	}
+
+	/* Comparison panel */
+	.comparison-panel {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		padding: 1rem;
+		margin-bottom: 1rem;
+	}
+
+	.comparison-panel h3 {
+		font-size: 0.9rem;
+		margin-bottom: 0.75rem;
+	}
+
+	/* Table */
+	.table-wrapper {
+		overflow-x: auto;
+	}
+
+	.sortable {
+		cursor: pointer;
+		user-select: none;
+	}
+
+	.sortable:hover {
+		color: var(--primary);
+	}
+
+	.col-check {
+		width: 36px;
+	}
+
+	.col-name {
+		min-width: 150px;
+	}
+
+	.col-mode {
+		width: 80px;
+	}
+
+	.col-size {
+		width: 100px;
+	}
+
+	.col-num {
+		width: 90px;
+		text-align: right;
+	}
+
+	.col-status {
+		width: 70px;
+	}
+
+	td.num {
+		text-align: right;
+		font-family: monospace;
+		font-size: 0.8rem;
+	}
+
+	.clickable {
+		cursor: pointer;
+	}
+
+	.clickable:hover {
+		color: var(--primary);
+	}
+
+	.result-row.expanded {
+		background: var(--surface);
+	}
+
+	.result-row.has-error {
+		opacity: 0.7;
+	}
+
+	.mode-badge {
+		font-size: 0.7rem;
+		padding: 0.1rem 0.4rem;
+		border-radius: 3px;
+		background: var(--surface);
+		color: var(--text-muted);
+		text-transform: uppercase;
+	}
+
+	.mode-badge.chat {
+		color: var(--primary);
+		background: rgba(79, 195, 247, 0.1);
+	}
+
+	.status-ok {
+		color: var(--success);
+		font-size: 0.8rem;
+	}
+
+	.status-error {
+		color: var(--danger);
+		font-size: 0.8rem;
+		cursor: help;
+	}
+
+	/* Expanded row */
+	.expanded-row td {
+		padding: 0;
+		border-bottom: 2px solid var(--border);
+	}
+
+	.expanded-content {
+		padding: 1rem;
+		background: var(--surface);
+	}
+
+	.expanded-content h4 {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin-bottom: 0.5rem;
+	}
+
+	.expanded-chart {
+		margin-bottom: 1.5rem;
+	}
+
+	.empty-filter {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 2rem;
+		font-size: 0.9rem;
 	}
 </style>

--- a/axis-viewer/pyproject.toml
+++ b/axis-viewer/pyproject.toml
@@ -11,7 +11,9 @@ dependencies = [
     "pydantic>=2.0",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
+    "python-multipart>=0.0.6",
     "pyyaml>=6.0",
+    "sse-starlette>=1.6.0",
     "torch>=2.0.0",
     "transformers>=4.40.0",
     "accelerate>=0.30.0",
@@ -27,6 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "httpx>=0.24.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

- **Batch upload**: `POST /api/batch/upload` accepts a JSONL file, parses each line as a conversation, saves to disk tagged with a `batch_id`
- **Streaming projection**: `POST /api/batch/{batch_id}/project` projects all conversations sequentially, streaming progress and results via SSE (Server-Sent Events)
- **Results table**: Sortable columns (name, mode, turns/tokens, mean projection, min projection, drift), filterable by name search, mode, and minimum drift threshold
- **Expandable rows**: Click any row to see full TokenHeatmap + TrajectoryChart inline
- **Comparison view**: Select 2+ conversations via checkboxes, overlay their trajectories on a shared ComparisonChart with per-conversation colors and legend
- **New `ComparisonChart` component**: Multi-trajectory SVG chart with shared axes, tooltips, and legend
- **15 backend tests** covering upload validation, SSE streaming, multi-conversation batches, raw/chat modes, error cases, and schema correctness

## Test plan

- [x] `npm run build` and `npm run check` pass with 0 errors, 0 warnings
- [x] All 29 backend tests pass (14 existing + 15 new batch tests)
- [ ] Manual test: upload a JSONL file with multiple conversations, verify progress bar, results table, expand rows, compare trajectories

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)