### PR TITLE
axis-viewer: Alternative model support (#19)

### DIFF
--- a/axis-viewer/backend/app.py
+++ b/axis-viewer/backend/app.py
@@ -10,10 +10,11 @@ import torch
 from fastapi import FastAPI
 from huggingface_hub import hf_hub_download
 
-from backend.config import AxisViewerConfig, load_config
+from backend.config import AVAILABLE_MODELS, AXIS_HF_REPO, AxisViewerConfig, load_config
 from backend.routes.batch import router as batch_router
 from backend.routes.conversations import router as conversations_router
 from backend.routes.generate import router as generate_router
+from backend.routes.models import router as models_router
 from backend.routes.project import router as project_router
 
 logger = logging.getLogger(__name__)
@@ -35,13 +36,16 @@ def _load_model_and_axis(config: AxisViewerConfig) -> dict:
     device = None if config.device == "auto" else config.device
     probing_model = ProbingModel(config.model_name, device=device)
 
+    # Determine axis path from AVAILABLE_MODELS or fall back to default
+    spec = AVAILABLE_MODELS.get(config.model_name)
+    axis_filename = spec.axis_path if spec else "qwen-3-32b/assistant_axis.pt"
+
     logger.info(
-        "Downloading axis from lu-christina/assistant-axis-vectors "
-        "(qwen-3-32b/assistant_axis.pt)"
+        "Downloading axis from %s (%s)", AXIS_HF_REPO, axis_filename,
     )
     axis_path = hf_hub_download(
-        repo_id="lu-christina/assistant-axis-vectors",
-        filename="qwen-3-32b/assistant_axis.pt",
+        repo_id=AXIS_HF_REPO,
+        filename=axis_filename,
         cache_dir=Path(config.data_dir) / "hf_cache",
     )
     axis = load_axis(axis_path)
@@ -66,6 +70,7 @@ async def lifespan(app: FastAPI):
     data_dir.mkdir(parents=True, exist_ok=True)
 
     app.state.config = config
+    app.state.model_switching = False
 
     if config.mock_model:
         logger.info("Running in mock mode -- skipping model loading")
@@ -103,6 +108,7 @@ def create_app(config_path: str = "config.yaml") -> FastAPI:
     app.include_router(batch_router)
     app.include_router(conversations_router)
     app.include_router(generate_router)
+    app.include_router(models_router)
     app.include_router(project_router)
 
     return app

--- a/axis-viewer/backend/app.py
+++ b/axis-viewer/backend/app.py
@@ -6,9 +6,7 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-import torch
 from fastapi import FastAPI
-from huggingface_hub import hf_hub_download
 
 from backend.config import AVAILABLE_MODELS, AXIS_HF_REPO, AxisViewerConfig, load_config
 from backend.routes.batch import router as batch_router
@@ -25,6 +23,8 @@ def _load_model_and_axis(config: AxisViewerConfig) -> dict:
 
     Returns a dict of objects to store on app.state.
     """
+    from huggingface_hub import hf_hub_download
+
     from assistant_axis.axis import load_axis
     from assistant_axis.internals import (
         ActivationExtractor,

--- a/axis-viewer/backend/config.py
+++ b/axis-viewer/backend/config.py
@@ -8,6 +8,54 @@ import yaml
 from pydantic import BaseModel
 
 
+class ModelSpec(BaseModel):
+    """Specification for a supported model."""
+
+    target_layer: int
+    total_layers: int
+    short_name: str
+    is_base: bool = False
+    has_capping: bool = False
+    axis_path: str  # path within the HF repo
+
+
+# All models the viewer can switch between.
+AVAILABLE_MODELS: dict[str, ModelSpec] = {
+    "Qwen/Qwen3-32B-AWQ": ModelSpec(
+        target_layer=32,
+        total_layers=64,
+        short_name="Qwen 3 32B",
+        is_base=False,
+        has_capping=True,
+        axis_path="qwen-3-32b/assistant_axis.pt",
+    ),
+    "google/gemma-2-27b-it": ModelSpec(
+        target_layer=22,
+        total_layers=46,
+        short_name="Gemma 2 27B",
+        is_base=False,
+        axis_path="gemma-2-27b/assistant_axis.pt",
+    ),
+    "google/gemma-2-27b": ModelSpec(
+        target_layer=22,
+        total_layers=46,
+        short_name="Gemma 2 27B Base",
+        is_base=True,
+        axis_path="gemma-2-27b/assistant_axis.pt",
+    ),
+    "meta-llama/Llama-3.3-70B-Instruct": ModelSpec(
+        target_layer=40,
+        total_layers=80,
+        short_name="Llama 3.3 70B",
+        is_base=False,
+        has_capping=True,
+        axis_path="llama-3.3-70b/assistant_axis.pt",
+    ),
+}
+
+AXIS_HF_REPO = "lu-christina/assistant-axis-vectors"
+
+
 class AxisViewerConfig(BaseModel):
     model_name: str = "Qwen/Qwen3-32B-AWQ"
     target_layer: int = 32

--- a/axis-viewer/backend/models.py
+++ b/axis-viewer/backend/models.py
@@ -46,6 +46,23 @@ class GenerateResponse(BaseModel):
     content: str
 
 
+# --- Model schemas ---
+
+
+class ModelInfo(BaseModel):
+    model_name: str
+    target_layer: int
+    total_layers: int
+    short_name: str
+    is_base: bool = False
+    has_capping: bool = False
+    status: str  # "loaded", "available", "switching"
+
+
+class ModelSwitchRequest(BaseModel):
+    model_name: str
+
+
 # --- Conversation save/load schemas ---
 
 

--- a/axis-viewer/backend/routes/models.py
+++ b/axis-viewer/backend/routes/models.py
@@ -1,0 +1,193 @@
+"""Model management endpoints: list, get current, and switch models."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+
+from backend.config import AVAILABLE_MODELS, ModelSpec
+from backend.models import ModelInfo, ModelSwitchRequest
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/models", tags=["models"])
+
+
+def _model_info(
+    model_name: str,
+    spec: ModelSpec,
+    current_model: str,
+    switching: bool,
+) -> ModelInfo:
+    """Build a ModelInfo response for a given model."""
+    if switching and model_name == current_model:
+        status = "switching"
+    elif model_name == current_model:
+        status = "loaded"
+    else:
+        status = "available"
+    return ModelInfo(
+        model_name=model_name,
+        target_layer=spec.target_layer,
+        total_layers=spec.total_layers,
+        short_name=spec.short_name,
+        is_base=spec.is_base,
+        has_capping=spec.has_capping,
+        status=status,
+    )
+
+
+@router.get("", response_model=list[ModelInfo])
+async def list_models(request: Request):
+    """List all available models with their current status."""
+    config = request.app.state.config
+    switching = getattr(request.app.state, "model_switching", False)
+    return [
+        _model_info(name, spec, config.model_name, switching)
+        for name, spec in AVAILABLE_MODELS.items()
+    ]
+
+
+@router.get("/current", response_model=ModelInfo)
+async def get_current_model(request: Request):
+    """Return info about the currently loaded model."""
+    config = request.app.state.config
+    switching = getattr(request.app.state, "model_switching", False)
+    spec = AVAILABLE_MODELS.get(config.model_name)
+    if spec is None:
+        # Fallback for unknown model (shouldn't happen normally)
+        spec = ModelSpec(
+            target_layer=config.target_layer,
+            total_layers=config.total_layers,
+            short_name=config.model_name.split("/")[-1],
+            axis_path="unknown",
+        )
+    return _model_info(config.model_name, spec, config.model_name, switching)
+
+
+def _do_model_switch(request: Request, model_name: str) -> None:
+    """Perform the actual model switch (blocking, runs in background thread).
+
+    This unloads the current model and loads the new one, then updates
+    app.state in-place.
+    """
+    from pathlib import Path
+
+    from huggingface_hub import hf_hub_download
+
+    from backend.config import AXIS_HF_REPO
+
+    config = request.app.state.config
+    spec = AVAILABLE_MODELS[model_name]
+
+    # Unload current model (already cleared in switch_model, but handle
+    # the case where close() needs to be called for GPU memory release)
+    current_model = request.app.state.probing_model
+    if current_model is not None:
+        logger.info("Closing previous model")
+        current_model.close()
+        request.app.state.probing_model = None
+        request.app.state.axis = None
+        request.app.state.encoder = None
+        request.app.state.extractor = None
+
+    # Load new model
+    from assistant_axis.axis import load_axis
+    from assistant_axis.internals import (
+        ActivationExtractor,
+        ConversationEncoder,
+        ProbingModel,
+    )
+
+    logger.info("Loading ProbingModel: %s", model_name)
+    device = None if config.device == "auto" else config.device
+    probing_model = ProbingModel(model_name, device=device)
+
+    logger.info("Downloading axis: %s", spec.axis_path)
+    axis_path = hf_hub_download(
+        repo_id=AXIS_HF_REPO,
+        filename=spec.axis_path,
+        cache_dir=Path(config.data_dir) / "hf_cache",
+    )
+    axis = load_axis(axis_path)
+    logger.info("Axis loaded with shape %s", axis.shape)
+
+    encoder = ConversationEncoder(probing_model.tokenizer, model_name)
+    extractor = ActivationExtractor(probing_model, encoder)
+
+    # Update app.state atomically
+    request.app.state.probing_model = probing_model
+    request.app.state.axis = axis
+    request.app.state.encoder = encoder
+    request.app.state.extractor = extractor
+
+    # Config was already updated in switch_model() before the background task
+    logger.info("Model switch to %s complete", model_name)
+
+
+async def _switch_model_background(request: Request, model_name: str) -> None:
+    """Run the model switch in a background thread and update status."""
+    try:
+        await asyncio.to_thread(_do_model_switch, request, model_name)
+    except Exception:
+        logger.exception("Model switch to %s failed", model_name)
+    finally:
+        request.app.state.model_switching = False
+
+
+@router.post("/switch", response_model=ModelInfo)
+async def switch_model(body: ModelSwitchRequest, request: Request):
+    """Switch to a different model.
+
+    In mock mode, this updates config values immediately without loading.
+    In real mode, the model swap runs in the background and the response
+    returns immediately with status ``"switching"``.
+    """
+    model_name = body.model_name
+    config = request.app.state.config
+
+    if model_name not in AVAILABLE_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown model: {model_name}. "
+            f"Available: {list(AVAILABLE_MODELS.keys())}",
+        )
+
+    if model_name == config.model_name:
+        # Already on this model
+        spec = AVAILABLE_MODELS[model_name]
+        switching = getattr(request.app.state, "model_switching", False)
+        return _model_info(model_name, spec, config.model_name, switching)
+
+    if getattr(request.app.state, "model_switching", False):
+        raise HTTPException(
+            status_code=409,
+            detail="A model switch is already in progress",
+        )
+
+    spec = AVAILABLE_MODELS[model_name]
+
+    if config.mock_model:
+        # In mock mode, just update the config values
+        config.model_name = model_name
+        config.target_layer = spec.target_layer
+        config.total_layers = spec.total_layers
+        return _model_info(model_name, spec, model_name, switching=False)
+
+    # Start background switch
+    request.app.state.model_switching = True
+    # Update model_name immediately so status queries reflect the target
+    config.model_name = model_name
+    config.target_layer = spec.target_layer
+    config.total_layers = spec.total_layers
+    # Clear model state so endpoints return 503 during the switch
+    request.app.state.probing_model = None
+    request.app.state.axis = None
+    request.app.state.encoder = None
+    request.app.state.extractor = None
+
+    asyncio.create_task(_switch_model_background(request, model_name))
+
+    return _model_info(model_name, spec, model_name, switching=True)

--- a/axis-viewer/backend/routes/project.py
+++ b/axis-viewer/backend/routes/project.py
@@ -6,8 +6,12 @@ import asyncio
 import logging
 import random
 
-import torch
+from typing import TYPE_CHECKING
+
 from fastapi import APIRouter, HTTPException, Request
+
+if TYPE_CHECKING:
+    import torch
 
 from backend.models import (
     ChatRequest,
@@ -47,8 +51,10 @@ def _project_tokens(
     -------
     List of scalar projection values, one per token.
     """
+    import torch as _torch
+
     axis_vec = axis[layer].float()
-    axis_norm = torch.norm(axis_vec)
+    axis_norm = _torch.norm(axis_vec)
     if axis_norm == 0:
         return [0.0] * activations.shape[0]
     axis_vec = axis_vec / axis_norm

--- a/axis-viewer/frontend/src/lib/api.ts
+++ b/axis-viewer/frontend/src/lib/api.ts
@@ -6,7 +6,8 @@ import type {
 	ProjectionResponse,
 	ConversationSummary,
 	ConversationDetail,
-	BatchUploadResponse
+	BatchUploadResponse,
+	ModelInfo
 } from './types';
 
 const BASE = '/api';
@@ -92,6 +93,23 @@ export async function deleteConversation(id: string): Promise<void> {
 
 export function exportConversationsUrl(): string {
 	return `${BASE}/conversations/export`;
+}
+
+// --- Model endpoints ---
+
+export async function listModels(): Promise<ModelInfo[]> {
+	return request<ModelInfo[]>('/models');
+}
+
+export async function getCurrentModel(): Promise<ModelInfo> {
+	return request<ModelInfo>('/models/current');
+}
+
+export async function switchModel(modelName: string): Promise<ModelInfo> {
+	return request<ModelInfo>('/models/switch', {
+		method: 'POST',
+		body: JSON.stringify({ model_name: modelName })
+	});
 }
 
 // --- Batch endpoints ---

--- a/axis-viewer/frontend/src/lib/model-state.svelte.ts
+++ b/axis-viewer/frontend/src/lib/model-state.svelte.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared reactive state for the currently loaded model.
+ *
+ * Uses a single exported object with $state properties so Svelte 5 module
+ * rules are satisfied (no reassigned exported $state bindings).
+ */
+
+import type { ModelInfo } from './types';
+
+interface ModelState {
+	models: ModelInfo[];
+	currentModel: ModelInfo | null;
+	isSwitching: boolean;
+}
+
+export const modelState: ModelState = $state({
+	models: [],
+	currentModel: null,
+	isSwitching: false
+});
+
+/** Update the models list and derive the current model from it. */
+export function setModels(list: ModelInfo[]) {
+	modelState.models = list;
+	const loaded = list.find((m) => m.status === 'loaded' || m.status === 'switching');
+	if (loaded) {
+		modelState.currentModel = loaded;
+		modelState.isSwitching = loaded.status === 'switching';
+	}
+}
+
+/** Mark a switch as in-progress and update the current model optimistically. */
+export function beginSwitch(model: ModelInfo) {
+	modelState.isSwitching = true;
+	modelState.currentModel = { ...model, status: 'switching' };
+	modelState.models = modelState.models.map((m) => ({
+		...m,
+		status:
+			m.model_name === model.model_name
+				? ('switching' as const)
+				: ('available' as const)
+	}));
+}
+
+/** Mark the switch as complete, refreshing from the given list. */
+export function finishSwitch(list: ModelInfo[]) {
+	modelState.isSwitching = false;
+	setModels(list);
+}

--- a/axis-viewer/frontend/src/lib/types.ts
+++ b/axis-viewer/frontend/src/lib/types.ts
@@ -47,6 +47,18 @@ export interface ConversationDetail {
 	created_at: string;
 }
 
+// --- Model types ---
+
+export interface ModelInfo {
+	model_name: string;
+	target_layer: number;
+	total_layers: number;
+	short_name: string;
+	is_base: boolean;
+	has_capping: boolean;
+	status: 'loaded' | 'available' | 'switching';
+}
+
 // --- Batch types ---
 
 export interface BatchUploadResponse {

--- a/axis-viewer/frontend/src/routes/+layout.svelte
+++ b/axis-viewer/frontend/src/routes/+layout.svelte
@@ -1,19 +1,103 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/state';
+	import { onMount } from 'svelte';
+	import { listModels, switchModel } from '$lib/api';
+	import {
+		modelState,
+		setModels,
+		beginSwitch,
+		finishSwitch
+	} from '$lib/model-state.svelte';
 
 	let { children } = $props();
+
+	let dropdownOpen = $state(false);
+	let switchError = $state('');
+	let pollInterval: ReturnType<typeof setInterval> | null = null;
 
 	const tabs = [
 		{ href: '/chat', label: 'Chat' },
 		{ href: '/raw', label: 'Raw Text' },
 		{ href: '/batch', label: 'Batch' }
 	];
+
+	onMount(async () => {
+		try {
+			const list = await listModels();
+			setModels(list);
+		} catch {
+			// Backend may not be reachable yet — ignore
+		}
+	});
+
+	async function handleSwitch(modelName: string) {
+		dropdownOpen = false;
+		switchError = '';
+
+		const target = modelState.models.find((m) => m.model_name === modelName);
+		if (!target || target.status === 'loaded') return;
+
+		beginSwitch(target);
+
+		try {
+			await switchModel(modelName);
+			// Poll for completion
+			startPolling();
+		} catch (e) {
+			switchError = e instanceof Error ? e.message : String(e);
+			// Refresh models list to get accurate state
+			try {
+				const list = await listModels();
+				finishSwitch(list);
+			} catch {
+				// ignore
+			}
+		}
+	}
+
+	function startPolling() {
+		if (pollInterval) return;
+		pollInterval = setInterval(async () => {
+			try {
+				const list = await listModels();
+				const switching = list.some((m) => m.status === 'switching');
+				if (!switching) {
+					finishSwitch(list);
+					stopPolling();
+				} else {
+					setModels(list);
+				}
+			} catch {
+				// ignore poll errors
+			}
+		}, 2000);
+	}
+
+	function stopPolling() {
+		if (pollInterval) {
+			clearInterval(pollInterval);
+			pollInterval = null;
+		}
+	}
+
+	function toggleDropdown() {
+		dropdownOpen = !dropdownOpen;
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.model-selector')) {
+			dropdownOpen = false;
+		}
+	}
 </script>
 
 <svelte:head>
 	<title>Axis Viewer</title>
 </svelte:head>
+
+<svelte:window onclick={handleClickOutside} />
 
 <div class="shell">
 	<header>
@@ -28,7 +112,66 @@
 				</a>
 			{/each}
 		</nav>
+
+		<div class="model-selector">
+			<button
+				class="model-btn"
+				onclick={toggleDropdown}
+				disabled={modelState.isSwitching}
+			>
+				{#if modelState.isSwitching}
+					<span class="mini-spinner"></span>
+					Switching...
+				{:else if modelState.currentModel}
+					{modelState.currentModel.short_name}
+					{#if modelState.currentModel.is_base}
+						<span class="base-badge">base</span>
+					{/if}
+				{:else}
+					Model
+				{/if}
+				<span class="caret">&#9662;</span>
+			</button>
+
+			{#if dropdownOpen}
+				<div class="model-dropdown">
+					{#each modelState.models as model}
+						<button
+							class="model-option"
+							class:active={model.status === 'loaded'}
+							onclick={() => handleSwitch(model.model_name)}
+							disabled={model.status === 'loaded' || modelState.isSwitching}
+						>
+							<span class="model-option-name">{model.short_name}</span>
+							<span class="model-option-meta">
+								layer {model.target_layer}/{model.total_layers}
+							</span>
+							{#if model.is_base}
+								<span class="base-badge">base</span>
+							{/if}
+							{#if model.status === 'loaded'}
+								<span class="loaded-badge">loaded</span>
+							{/if}
+						</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
 	</header>
+
+	{#if switchError}
+		<div class="switch-error">
+			Model switch failed: {switchError}
+		</div>
+	{/if}
+
+	{#if modelState.isSwitching}
+		<div class="switch-banner">
+			<span class="mini-spinner"></span>
+			Switching model to {modelState.currentModel?.short_name}... This may take 30-60 seconds.
+		</div>
+	{/if}
+
 	<main>
 		{@render children()}
 	</main>
@@ -71,5 +214,141 @@
 	nav a.active {
 		background: var(--surface);
 		color: var(--primary);
+	}
+
+	/* Model selector */
+	.model-selector {
+		margin-left: auto;
+		position: relative;
+	}
+	.model-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.35rem 0.75rem;
+		font-size: 0.8rem;
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		background: var(--surface);
+		color: var(--text);
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.model-btn:hover {
+		background: var(--surface-hover);
+	}
+	.model-btn:disabled {
+		opacity: 0.7;
+		cursor: not-allowed;
+	}
+	.caret {
+		font-size: 0.6rem;
+		color: var(--text-muted);
+	}
+	.model-dropdown {
+		position: absolute;
+		top: 100%;
+		right: 0;
+		margin-top: 0.25rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		min-width: 240px;
+		z-index: 100;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	}
+	.model-option {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border: none;
+		background: none;
+		color: var(--text);
+		font-size: 0.8rem;
+		text-align: left;
+		cursor: pointer;
+		border-radius: 0;
+	}
+	.model-option:first-child {
+		border-radius: 6px 6px 0 0;
+	}
+	.model-option:last-child {
+		border-radius: 0 0 6px 6px;
+	}
+	.model-option:hover:not(:disabled) {
+		background: var(--surface-hover);
+	}
+	.model-option.active {
+		color: var(--primary);
+	}
+	.model-option:disabled {
+		cursor: default;
+	}
+	.model-option-name {
+		font-weight: 500;
+	}
+	.model-option-meta {
+		color: var(--text-muted);
+		font-size: 0.7rem;
+		font-family: monospace;
+	}
+	.base-badge {
+		font-size: 0.65rem;
+		padding: 0.1rem 0.3rem;
+		border-radius: 3px;
+		background: rgba(255, 167, 38, 0.15);
+		color: var(--warning);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+	.loaded-badge {
+		font-size: 0.65rem;
+		padding: 0.1rem 0.3rem;
+		border-radius: 3px;
+		background: rgba(102, 187, 106, 0.15);
+		color: var(--success);
+		font-weight: 600;
+	}
+
+	/* Switch banner */
+	.switch-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		margin-bottom: 1rem;
+		background: rgba(79, 195, 247, 0.08);
+		border: 1px solid var(--primary);
+		border-radius: 4px;
+		font-size: 0.825rem;
+		color: var(--primary);
+	}
+	.switch-error {
+		padding: 0.5rem 0.75rem;
+		margin-bottom: 1rem;
+		background: rgba(239, 83, 80, 0.1);
+		border: 1px solid var(--danger);
+		border-radius: 4px;
+		font-size: 0.825rem;
+		color: var(--danger);
+	}
+
+	/* Mini spinner (used in button and banner) */
+	.mini-spinner {
+		display: inline-block;
+		width: 12px;
+		height: 12px;
+		border: 2px solid var(--border);
+		border-top-color: var(--primary);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 </style>

--- a/axis-viewer/frontend/src/routes/chat/+page.svelte
+++ b/axis-viewer/frontend/src/routes/chat/+page.svelte
@@ -3,6 +3,7 @@
 	import TokenHeatmap from '$lib/components/TokenHeatmap.svelte';
 	import TrajectoryChart from '$lib/components/TrajectoryChart.svelte';
 	import SaveLoadPanel from '$lib/components/SaveLoadPanel.svelte';
+	import { modelState } from '$lib/model-state.svelte';
 	import type { ProjectionResponse, ConversationDetail } from '$lib/types';
 
 	// ---- State ----
@@ -18,6 +19,8 @@
 	let systemPromptOpen = $state(false);
 	let temperature = $state(0.7);
 	let maxTokens = $state(512);
+
+	let isBaseModel = $derived(modelState.currentModel?.is_base ?? false);
 
 	// Loading states
 	let generating = $state(false);
@@ -227,7 +230,7 @@
 		messages.length > 0 ? messages[0].content.slice(0, 50) : ''
 	);
 
-	let busy = $derived(generating || projecting);
+	let busy = $derived(generating || projecting || modelState.isSwitching);
 </script>
 
 <div class="chat-layout">
@@ -286,6 +289,14 @@
 				<button class="danger clear-btn" onclick={clearAll}>Clear All</button>
 			{/if}
 		</div>
+
+		<!-- Base model notice -->
+		{#if isBaseModel}
+			<div class="base-model-notice">
+				Chat mode is unavailable for base models. Use
+				<a href="/raw">Raw Text</a> mode instead.
+			</div>
+		{/if}
 
 		<!-- Messages -->
 		<div class="messages" bind:this={messagesContainer}>
@@ -398,8 +409,8 @@
 				rows="2"
 				disabled={busy}
 			></textarea>
-			<button class="primary send-btn" onclick={sendMessage} disabled={busy || !inputText.trim()}>
-				{generating ? 'Generating...' : 'Send'}
+			<button class="primary send-btn" onclick={sendMessage} disabled={busy || !inputText.trim() || isBaseModel}>
+				{generating ? 'Generating...' : isBaseModel ? 'Unavailable (base model)' : 'Send'}
 			</button>
 		</div>
 	</div>
@@ -502,6 +513,21 @@
 		margin-left: auto;
 		padding: 0.3rem 0.6rem;
 		font-size: 0.75rem;
+	}
+
+	/* Base model notice */
+	.base-model-notice {
+		padding: 0.6rem 0.75rem;
+		background: rgba(255, 167, 38, 0.08);
+		border: 1px solid var(--warning);
+		border-radius: 4px;
+		font-size: 0.825rem;
+		color: var(--warning);
+		margin-bottom: 0.5rem;
+	}
+	.base-model-notice a {
+		color: var(--primary);
+		text-decoration: underline;
 	}
 
 	/* Messages area */


### PR DESCRIPTION
## Summary
- Add runtime model switching between Qwen 3 32B, Gemma 2 27B (instruct + base), and Llama 3.3 70B
- New backend endpoints: `GET /api/models`, `GET /api/models/current`, `POST /api/models/switch`
- Model swap runs in a background thread (30-60s) with polling for completion; mock mode switches instantly
- Frontend model selector dropdown in the nav bar shows current model, loading state during switch, and base model badges
- Chat mode is disabled for base models with a notice directing users to Raw Text mode

## Test plan
- [ ] Start backend in mock mode (`mock_model: true`) and verify model selector lists all 4 models
- [ ] Switch models in mock mode and confirm instant status update
- [ ] Verify chat page shows "base" warning and disables send button when a base model is selected
- [ ] With a real GPU, verify background model switch loads new model and axis correctly
- [ ] Verify projection endpoints return 503 during active model switch
- [ ] Confirm frontend polling detects switch completion and updates UI

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)